### PR TITLE
Fixes #17 - Add space surrounding "wrapText"

### DIFF
--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -1395,7 +1395,7 @@ Workbook$methods(
       
       if (!is.null(style$wrapText)) {
         if (style$wrapText)
-          alignNode <- stri_join(alignNode, 'wrapText="1"')
+          alignNode <- stri_join(alignNode, 'wrapText="1"', sep = " ")
       }
       
       


### PR DESCRIPTION
When "wrapText = TRUE", surround it in spaces in the raw xml markup.
Tested and confirmed working.
Fixes issue #17.