### PR TITLE
dataValidation rows/cols *must* be contiguous

### DIFF
--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -2882,8 +2882,8 @@ setFooter <- function(wb, text, position = "center"){
 #' @description Add Excel data validation to cells 
 #' @param wb A workbook object
 #' @param sheet A name or index of a worksheet
-#' @param cols Columns to apply conditional formatting to
-#' @param rows Rows to apply conditional formatting to
+#' @param cols Contiguous columns to apply conditional formatting to
+#' @param rows Contiguous rows to apply conditional formatting to
 #' @param type One of 'whole', 'decimal', 'date', 'time', 'textLength', 'list' (see examples)
 #' @param operator One of 'between', 'notBetween', 'equal',
 #'  'notEqual', 'greaterThan', 'lessThan', 'greaterThanOrEqual', 'lessThanOrEqual'

--- a/docs/reference/dataValidation.html
+++ b/docs/reference/dataValidation.html
@@ -143,11 +143,11 @@
     </tr>
     <tr>
       <th>cols</th>
-      <td><p>Columns to apply conditional formatting to</p></td>
+      <td><p>Contiguous columns to apply conditional formatting to</p></td>
     </tr>
     <tr>
       <th>rows</th>
-      <td><p>Rows to apply conditional formatting to</p></td>
+      <td><p>Contiguous rows to apply conditional formatting to</p></td>
     </tr>
     <tr>
       <th>type</th>

--- a/man/dataValidation.Rd
+++ b/man/dataValidation.Rd
@@ -22,9 +22,9 @@ dataValidation(
 
 \item{sheet}{A name or index of a worksheet}
 
-\item{cols}{Columns to apply conditional formatting to}
+\item{cols}{Contiguous columns to apply conditional formatting to}
 
-\item{rows}{Rows to apply conditional formatting to}
+\item{rows}{Contiguous rows to apply conditional formatting to}
 
 \item{type}{One of 'whole', 'decimal', 'date', 'time', 'textLength', 'list' (see examples)}
 


### PR DESCRIPTION
Data validation rows and columns are specified via `startRow` and `endRow` arguments ([R/wrappers.R:3015](https://github.com/ycphs/openxlsx/blob/8ca14f5f0965c215c77db30884836d4c8aeed43e/R/wrappers.R#L3015)), so the `rows` and `cols` parameters to `dataValidation()` must be contiguous (e.g., `cols = 1:3` is supported, `cols = c(1, 3, 5)` is not). This updates the documentation. `dataValidation()` could be updated to take non-contiguous rows/cols, but based on the current method, would need to add an entry for *each* row/column desired.