### PR TITLE
Write mixed EDT/EST DateTimes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 *  Fixed NEWS hyperlink
 
+*  Fixed writing of mixed EST/EDT datetimes.
+
 # openxlsx 4.1.4
 
 *  Use `zip::zipr()` instead of `zip::zip()`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 *  Fixed NEWS hyperlink
 
-*  Fixed writing of mixed EST/EDT datetimes.
+*  Fixed writing of mixed EST/EDT datetimes
 
 # openxlsx 4.1.4
 

--- a/R/workbook_write_data.R
+++ b/R/workbook_write_data.R
@@ -40,30 +40,25 @@ Workbook$methods(writeData = function(df, sheet, startRow, startCol, colNames, c
     for(i in dInds)
       df[[i]] <- as.integer(df[[i]]) + origin
     
-    
-    
     pInds <- which(sapply(colClasses, function(x) any(c("posixct", "posixt", "posixlt") %in% x)))
-    if(length(pInds) > 0 & nRows > 0){
-      t <- sapply(pInds,  function(i) {
-        tzi <- format(df[[i]][[1]], "%z")
-        if(is.na(tzi)){
-          tz_tmp <- na.omit(df[[i]])
-          tzi <- ifelse(length(tz_tmp) > 0, format(tz_tmp[1], "%z"), NA)
-        }
-        return(tzi)
-      })
+    if(length(pInds) > 0 & nRows > 0) {
       
-      offSet <- suppressWarnings(ifelse(substr(t,1,1) == "+", 1L, -1L) * (as.integer(substr(t,2,3)) + as.integer(substr(t,4,5)) / 60) / 24)
+      parseOffset <- function(tz) {
+        suppressWarnings(
+          ifelse(stri_sub(tz, 1, 1) == "+", 1L, -1L) 
+          * (as.integer(stri_sub(tz, 2, 3)) + as.integer(stri_sub(tz, 4, 5)) / 60) / 24
+        )
+      }
+      
+      t      <- lapply(df[pInds], function(x) format(x, "%z"))
+      offSet <- lapply(t, parseOffset)
+      offSet <- lapply(offSet, function(x) ifelse(is.na(x), 0, x))
       
       for(i in 1:length(pInds)){
-        
-        if(is.na(offSet[i]))
-          offSet[i] <- 0
-        
-        df[[pInds[i]]] <- as.numeric(as.POSIXct(df[[pInds[i]]])) / 86400 + origin + offSet[i]
-        
+        df[[pInds[i]]] <- as.numeric(as.POSIXct(df[[pInds[i]]])) / 86400 + origin + offSet[[i]]
       }
     }
+    
   }
   
   

--- a/tests/testthat/test-writing_posixct.R
+++ b/tests/testthat/test-writing_posixct.R
@@ -41,3 +41,40 @@ test_that("Writing Posixct with writeData & writeDataTable", {
   
 })
 
+test_that("Writing mixed EDT/EST Posixct with writeData & writeDataTable", {
+  
+  options("openxlsx.datetimeFormat" = "dd/mm/yy hh:mm")
+  
+  tstart1 <- strptime("12/03/2018 08:30", "%d/%m/%Y %H:%M", tz="America/New_York")
+  tstart2 <- strptime("10/03/2018 08:30", "%d/%m/%Y %H:%M", tz="America/New_York")
+  TimeDT1 <- c(0,10,30,60,120,240,720,1440)*60 + tstart1
+  TimeDT2 <- c(0,10,30,60,120,240,720,1440)*60 + tstart2
+  
+  df <- data.frame(timeval = c(TimeDT1, TimeDT2),
+                   timetxt = format(c(TimeDT1, TimeDT2),"%Y-%m-%d %H:%M"))
+  
+  wb <- createWorkbook()
+  addWorksheet(wb, "writeData")
+  addWorksheet(wb, "writeDataTable")
+  
+  writeData(wb, "writeData", df, startCol = 2, startRow = 3, rowNames = FALSE)
+  writeDataTable(wb, "writeDataTable", df, startCol = 2, startRow = 3)
+  
+  wd <- as.numeric(wb$worksheets[[1]]$sheet_data$v)
+  wdt <- as.numeric(wb$worksheets[[2]]$sheet_data$v)
+  
+  
+  expected <- c(0, 1, 43171.3541666667, 2, 43171.3611111111, 3, 43171.3750000000,
+                4, 43171.3958333333, 5, 43171.4375000000, 6, 43171.5208333333, 7, 
+                43171.8541666667, 8, 43172.3541666667, 9, 43169.3541666667, 10, 
+                43169.3611111111, 11, 43169.3750000000, 12, 43169.3958333333, 13, 
+                43169.4375000000, 14, 43169.5208333333, 15, 43169.8541666667, 16,
+                43170.3958333333, 17)
+  
+  expect_equal(object = round(wd, 12), expected = expected)
+  expect_equal(object = round(wdt, 12), expected = expected)
+  expect_equal(object = wd, expected = wdt)
+  
+  options("openxlsx.datetimeFormat" = "yyyy-mm-dd hh:mm:ss")
+  
+})

--- a/tests/testthat/test-writing_posixct.R
+++ b/tests/testthat/test-writing_posixct.R
@@ -71,8 +71,8 @@ test_that("Writing mixed EDT/EST Posixct with writeData & writeDataTable", {
                 43169.4375000000, 14, 43169.5208333333, 15, 43169.8541666667, 16,
                 43170.3958333333, 17)
   
-  expect_equal(object = round(wd, 12), expected = expected)
-  expect_equal(object = round(wdt, 12), expected = expected)
+  expect_equal(object = wd, expected = expected)
+  expect_equal(object = wdt, expected = expected)
   expect_equal(object = wd, expected = wdt)
   
   options("openxlsx.datetimeFormat" = "yyyy-mm-dd hh:mm:ss")

--- a/tests/testthat/test-writing_posixct.R
+++ b/tests/testthat/test-writing_posixct.R
@@ -63,16 +63,13 @@ test_that("Writing mixed EDT/EST Posixct with writeData & writeDataTable", {
   wd <- as.numeric(wb$worksheets[[1]]$sheet_data$v)
   wdt <- as.numeric(wb$worksheets[[2]]$sheet_data$v)
   
+  expected <- c(0, 1, 43171.354166666700621, 2, 43171.361111111102218, 3, 43171.375, 4, 43171.395833333299379,
+                5, 43171.4375, 6, 43171.520833333299379, 7, 43171.854166666700621, 8, 43172.354166666700621,
+                9, 43169.354166666700621, 10, 43169.361111111102218, 11, 43169.375, 12, 43169.395833333299379,
+                13, 43169.4375, 14, 43169.520833333299379, 15, 43169.854166666700621, 16, 43170.395833333299379, 17)
   
-  expected <- c(0, 1, 43171.3541666667, 2, 43171.3611111111, 3, 43171.3750000000,
-                4, 43171.3958333333, 5, 43171.4375000000, 6, 43171.5208333333, 7, 
-                43171.8541666667, 8, 43172.3541666667, 9, 43169.3541666667, 10, 
-                43169.3611111111, 11, 43169.3750000000, 12, 43169.3958333333, 13, 
-                43169.4375000000, 14, 43169.5208333333, 15, 43169.8541666667, 16,
-                43170.3958333333, 17)
-  
-  expect_equal(object = wd, expected = expected)
-  expect_equal(object = wdt, expected = expected)
+  expect_equal(object = round(wd, 12), expected = round(expected, 12))
+  expect_equal(object = round(wdt, 12), expected = round(expected, 12))
   expect_equal(object = wd, expected = wdt)
   
   options("openxlsx.datetimeFormat" = "yyyy-mm-dd hh:mm:ss")

--- a/tests/testthat/test-writing_posixct.R
+++ b/tests/testthat/test-writing_posixct.R
@@ -41,14 +41,15 @@ test_that("Writing Posixct with writeData & writeDataTable", {
   
 })
 
+
 test_that("Writing mixed EDT/EST Posixct with writeData & writeDataTable", {
   
   options("openxlsx.datetimeFormat" = "dd/mm/yy hh:mm")
   
   tstart1 <- strptime("12/03/2018 08:30", "%d/%m/%Y %H:%M", tz="America/New_York")
   tstart2 <- strptime("10/03/2018 08:30", "%d/%m/%Y %H:%M", tz="America/New_York")
-  TimeDT1 <- c(0,10,30,60,120,240,720,1440)*60 + tstart1
-  TimeDT2 <- c(0,10,30,60,120,240,720,1440)*60 + tstart2
+  TimeDT1 <- c(NA, 0,10,30,60,120,240,720,1440)*60 + tstart1
+  TimeDT2 <- c(0,10,30,60,120,240,720,NA,1440)*60 + tstart2
   
   df <- data.frame(timeval = c(TimeDT1, TimeDT2),
                    timetxt = format(c(TimeDT1, TimeDT2),"%Y-%m-%d %H:%M"))
@@ -60,16 +61,23 @@ test_that("Writing mixed EDT/EST Posixct with writeData & writeDataTable", {
   writeData(wb, "writeData", df, startCol = 2, startRow = 3, rowNames = FALSE)
   writeDataTable(wb, "writeDataTable", df, startCol = 2, startRow = 3)
   
-  wd <- as.numeric(wb$worksheets[[1]]$sheet_data$v)
+  wd  <- as.numeric(wb$worksheets[[1]]$sheet_data$v)
   wdt <- as.numeric(wb$worksheets[[2]]$sheet_data$v)
+  wd  <- wd[wb$worksheets[[1]]$sheet_data$cols == 2]
+  wdt <- wdt[wb$worksheets[[2]]$sheet_data$cols == 2]
   
-  expected <- c(0, 1, 43171.354166666700621, 2, 43171.361111111102218, 3, 43171.375, 4, 43171.395833333299379,
-                5, 43171.4375, 6, 43171.520833333299379, 7, 43171.854166666700621, 8, 43172.354166666700621,
-                9, 43169.354166666700621, 10, 43169.361111111102218, 11, 43169.375, 12, 43169.395833333299379,
-                13, 43169.4375, 14, 43169.520833333299379, 15, 43169.854166666700621, 16, 43170.395833333299379, 17)
+  # drop any integer indexes introduced in write
+  wd  <- wd[wd%%1 > 0 | is.na(wd)]
+  wdt <- wdt[wdt%%1 > 0 | is.na(wdt)]
   
-  expect_equal(object = round(wd, 12), expected = round(expected, 12))
-  expect_equal(object = round(wdt, 12), expected = round(expected, 12))
+  # sort everything
+  wd  <- convertToDateTime(wd[order(wd)])
+  wdt <- convertToDateTime(wdt[order(wdt)])
+  expected <- df$timeval[order(df$timeval)]
+  
+  # compare
+  expect_equal(object = wd, expected = expected, tolerance = 10^-10)
+  expect_equal(object = wdt, expected = expected, tolerance = 10^-10)
   expect_equal(object = wd, expected = wdt)
   
   options("openxlsx.datetimeFormat" = "yyyy-mm-dd hh:mm:ss")


### PR DESCRIPTION
This PR adapts the existing write to worksheet code so that all values' timezones in a datetime column are considered rather than only the first non-na value's timezone.

fixes issue #64 