### PR TITLE
Fix Bug #47: Protected workbooks generate Ecxel-error after loading withh openxlsx

### DIFF
--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -70,7 +70,6 @@ Workbook$methods(
 
     workbook <<- genBaseWorkbook()
     workbook.xml.rels <<- genBaseWorkbook.xml.rels()
-    workbookProtection <<- NULL
 
     worksheets <<- list()
     worksheets_rels <<- list()
@@ -1013,20 +1012,6 @@ Workbook$methods(
           "</definedNames>"
         )
     }
-
-
-
-    if (length(workbookProtection) > 0) {
-      # Worksheet protection needs to be right after fileVersion, fileSharing and workbookPr, otherwise Excel will complain
-      workbookXML <-
-        append(workbookXML,
-          list(workbookProtection = workbookProtection),
-          after = max(which(
-            names(workbookXML) %in% c("fileVersion", "fileSharing", "workbookPr")
-          ))
-        )
-    }
-
 
     write_file(
       head = '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">',
@@ -17971,8 +17956,9 @@ Workbook$methods(
     if (!missing(lockWindows) && !is.null(lockWindows)) {
       attr["lockWindows"] <- toString(as.numeric(lockWindows))
     }
+    # TODO: Shall we parse the existing protection settings and preserve all unchanged attributes?
     if (protect) {
-      workbookProtection <<-
+      workbook$workbookProtection <<-
         sprintf(
           "<workbookProtection %s/>",
           stri_join(
@@ -17985,7 +17971,7 @@ Workbook$methods(
           )
         )
     } else {
-      workbookProtection <<- ""
+      workbook$workbookProtection <<- ""
     }
   }
 )

--- a/R/baseXML.R
+++ b/R/baseXML.R
@@ -184,6 +184,7 @@ genBaseWorkbook.xml.rels <- function() {
 genBaseWorkbook <- function() {
   list(
     workbookPr = '<workbookPr date1904="false"/>',
+    workbookProtection = NULL,
     bookViews = '<bookViews><workbookView xWindow="0" yWindow="0" windowWidth="13125" windowHeight="6105"/></bookViews>',
     sheets = NULL,
     externalReferences = NULL,

--- a/R/class_definitions.R
+++ b/R/class_definitions.R
@@ -5,7 +5,6 @@
 Workbook <- setRefClass("Workbook",
   fields = c(
     "sheet_names" = "character",
-    "workbookProtection" = "ANY",
 
     "charts" = "ANY",
     "isChartSheet" = "logical",

--- a/tests/testthat/test-protect-workbook.R
+++ b/tests/testthat/test-protect-workbook.R
@@ -9,8 +9,23 @@ test_that("Protect Workbook", {
 
   wb$protectWorkbook(password = "abcdefghij")
 
-  expect_true(wb$workbookProtection == "<workbookProtection workbookPassword=\"FEF1\"/>")
+  expect_true(wb$workbook$workbookProtection == "<workbookProtection workbookPassword=\"FEF1\"/>")
 
   wb$protectWorkbook(protect = FALSE, password = "abcdefghij", lockStructure = TRUE, lockWindows = TRUE)
-  expect_true(wb$workbookProtection == "")
+  expect_true(wb$workbook$workbookProtection == "")
+})
+
+test_that("Reading protected Workbook", {
+  tmp_file <- file.path(tempdir(), "xlsx_read_protectedwb.xlsx")
+
+  wb <- createWorkbook()
+  addWorksheet(wb, "s1")
+  protectWorkbook(wb, password = "abcdefghij")
+  saveWorkbook(wb, tmp_file, overwrite = TRUE)
+  
+  wb2 <- loadWorkbook(file = tmp_file)
+  # Check that the order of teh sub-elements is preserved
+  expect_equal(names(wb2$workbook), names(wb$workbook))
+
+  unlink(tmp_file, recursive = TRUE, force = TRUE)
 })


### PR DESCRIPTION
=> Fix order of workbook subelements

The workbook protection settings (part of the workbook XML file) were incorrectly implemented, so that loading a protected workbook in openxlsx caused the workbookProtection XML tag to be appended to the workbook tag. The spec, however, demands a given order of the elements, so Excel printed a warning when a protected file was read and re-written using openxlsx.

The fix is to add a NULL workbookProtection to the default fields of the workbook object, so it will always be in the correct position. Reading then simply needs to read the corresponding tag from the XML, and writing does not need anything special.

Fixes bug #47