### PR TITLE
Fix issue #30: Improve error reporting (include offending sheet name).

### DIFF
--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -371,7 +371,7 @@ addWorksheet <- function(wb, sheetName,
   }
 
   if (tolower(sheetName) %in% tolower(wb$sheet_names)) {
-    stop("A worksheet by that name already exists! Sheet names must be unique case-insensitive.")
+    stop(paste0("A worksheet by the name '", sheetName, "' already exists! Sheet names must be unique case-insensitive."))
   }
 
   if (!is.logical(gridLines) | length(gridLines) > 1) {
@@ -379,7 +379,7 @@ addWorksheet <- function(wb, sheetName,
   }
 
   if (nchar(sheetName) > 31) {
-    stop("sheetName too long! Max length is 31 characters.")
+    stop(paste0("sheetName '", sheetName, "' too long! Max length is 31 characters."))
   }
 
   if (!is.null(tabColour)) {


### PR DESCRIPTION
When complaining about sheet name issues (duplicates, too long), write out the offending name in the error message