### PR TITLE
Fix misleading indentation in convert_to_excel_ref_expand

### DIFF
--- a/src/helper_functions.cpp
+++ b/src/helper_functions.cpp
@@ -170,7 +170,7 @@ SEXP convert_to_excel_ref_expand(const std::vector<int>& cols, const std::vector
       c++;
     }
     
-    r.attr("names") = names;
+  r.attr("names") = names;
   return wrap(r) ;
   
 }


### PR DESCRIPTION
GCC warns about this:

```
helper_functions.cpp: In function ‘SEXPREC* convert_to_excel_ref_expand(
  const std::vector<int>&,
  const std::vector<std::__cxx11::basic_string<char> >&,
  const std::vector<std::__cxx11::basic_string<char> >&)’:
helper_functions.cpp:166:3: warning: this ‘for’ clause does not guard...
  [-Wmisleading-indentation]
  166 |   for(int i=0; i < nRows; i++)
      |   ^~~
helper_functions.cpp:173:5: note: ...this statement, but the latter is
  misleadingly indented as if it were guarded by the ‘for’
  173 |     r.attr("names") = names;
      |     ^
```