### PR TITLE
Fix index for `hidden` attribute when grouping columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,18 +1,22 @@
 # openxlsx (development version)
 
+## Bug Fixes
+
+* Grouping columns after setting widths no longer throws an error ([#100](https://github.com/ycphs/openxlsx/issues/100))
+
 # openxlsx 4.2.2
 
 ## New Features
 
 * Added features for `conditionalFormatting` to support also 'contains not', 'begins with' and 'ends with'
 
-* Added return value for `saveWorkbook()` the default value for `returnValue` is `FALSE` ([#71])(https://github.com/ycphs/openxlsx/issues/71)
+* Added return value for `saveWorkbook()` the default value for `returnValue` is `FALSE` ([#71](https://github.com/ycphs/openxlsx/issues/71))
 
 * Added Tests for new parameter of `saveWorkbook()`
 
 ## Bug Fixes 
  
-* Solved CRAN check errors based on the change disussed in  (PR#17277)[https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=17277]
+* Solved CRAN check errors based on the change disussed in [PR#17277](https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=17277)
 
 # openxlsx 4.2.0
 

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -4292,9 +4292,8 @@ groupColumns <- function(wb, sheet, cols, hidden = FALSE) {
   }
   
   levels <- rep("1", length(cols))
-  
   hidden <- rep(hidden, length.out = length(cols))
-  
+
   hidden <- hidden[!duplicated(cols)]
   levels <- levels[!duplicated(cols)]
   cols <- cols[!duplicated(cols)]
@@ -4307,8 +4306,8 @@ groupColumns <- function(wb, sheet, cols, hidden = FALSE) {
     if (any(existing_cols %in% cols)) {
       for (i in intersect(existing_cols, cols)) {
         width_hidden <- attr(wb$colWidths[[sheet]], "hidden")[attr(wb$colWidths[[sheet]], "names") == i]
-        outline_hidden <- as.character(as.integer(hidden[i]))
-        
+        outline_hidden <- as.character(as.integer(hidden))[cols == i]
+
         if (width_hidden != outline_hidden) {
           attr(wb$colWidths[[sheet]], "hidden")[attr(wb$colWidths[[sheet]], "names") == i] <- outline_hidden
         }

--- a/tests/testthat/test-outlines.R
+++ b/tests/testthat/test-outlines.R
@@ -69,3 +69,22 @@ test_that("loading workbook preserves outlines", {
   expect_equal(names(wb$outlineLevels[[1]]), c("3", "4"))
   expect_equal(unique(attr(wb$outlineLevels[[1]], "hidden")[names(wb$outlineLevels[[1]]) %in% c("3", "4")]), "true")
 })
+
+
+test_that("Grouping after setting colwidths has correct length of hidden attributes", {
+  # Issue #100 - https://github.com/ycphs/openxlsx/issues/100
+
+  wb <- createWorkbook(title = "column width and grouping error")
+  addWorksheet(wb, sheetName = 1)
+
+  setColWidths(
+    wb,
+    sheet = 1,
+    cols = 1:100,
+    widths = 8
+  )
+
+  groupColumns(wb, sheet = 1, cols = 20:100, hidden = TRUE)
+
+  expect_equal(length(wb$colOutlineLevels[[1]]), length(attr(wb$colOutlineLevels[[1]], "hidden")))
+})


### PR DESCRIPTION
When grouping a *subset* of columns after setting custom widths,
the index for the `hidden` attribute would start from 1, resulting
in fewer than expected `hidden` values.
It should now correctly match the columns that intersect with those
set by the earlier call to `setColWidths()`.
Fixes #100 