### PR TITLE
editing documentation to match output

### DIFF
--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -2407,7 +2407,7 @@ protectWorkbook <- function(wb, protect = TRUE, password = NULL, lockStructure =
 #' @author Alexander Walker
 #' @param wb A workbook object
 #' @param sheet A name or index of a worksheet
-#' @param showGridLines A logical. If \code{TRUE}, grid lines are hidden.
+#' @param showGridLines A logical. If \code{FALSE}, grid lines are hidden.
 #' @export
 #' @examples
 #' wb <- loadWorkbook(file = system.file("extdata", "loadExample.xlsx", package = "openxlsx"))

--- a/man/showGridLines.Rd
+++ b/man/showGridLines.Rd
@@ -11,7 +11,7 @@ showGridLines(wb, sheet, showGridLines = FALSE)
 
 \item{sheet}{A name or index of a worksheet}
 
-\item{showGridLines}{A logical. If \code{TRUE}, grid lines are hidden.}
+\item{showGridLines}{A logical. If \code{FALSE}, grid lines are hidden.}
 }
 \description{
 Set worksheet gridlines to show or hide.


### PR DESCRIPTION
Currently, the documentation suggest that `showGridLines(wb, sheet, showGridLines = TRUE)` hides the gridlines, when  `showGridLines(wb, sheet, showGridLines = FALSE)` does that.