### PR TITLE
replace 1:length() with seq_along()

### DIFF
--- a/R/CommentClass.R
+++ b/R/CommentClass.R
@@ -31,7 +31,7 @@ Comment$methods(show = function() {
   styleShow <- "Style:\n"
 
   if ("list" %in% class(style)) {
-    for (i in 1:length(style)) {
+    for (i in seq_along(style)) {
       styleShow <- append(styleShow, sprintf("Font name: %s\n", style[[i]]$fontName[[1]])) ## Font name
       styleShow <- append(styleShow, sprintf("Font size: %s\n", style[[i]]$fontSize[[1]])) ## Font size
       styleShow <- append(styleShow, sprintf("Font colour: %s\n", gsub("^FF", "#", style[[i]]$fontColour[[1]]))) ## Font colour

--- a/R/HyperlinkClass.R
+++ b/R/HyperlinkClass.R
@@ -71,7 +71,7 @@ xml_to_hyperlink <- function(xml) {
     x
   })
 
-  hyperlink_objects <- lapply(1:length(xml), function(i) {
+  hyperlink_objects <- lapply(seq_along(xml), function(i) {
     tmp_vals <- vals[[i]]
     tmp_nms <- names[[i]]
     names(tmp_vals) <- tmp_nms

--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -715,7 +715,7 @@ Workbook$methods(
         file.path(tmpDir, "xl", "pivotCache", "_rels")
       dir.create(path = pivotCacheRelsDir, recursive = TRUE)
 
-      for (i in 1:length(pivotTables)) {
+      for (i in seq_along(pivotTables)) {
         file.copy(
           from = pivotTables[i],
           to = file.path(pivotTablesDir, sprintf("pivotTable%s.xml", i)),
@@ -724,7 +724,7 @@ Workbook$methods(
         )
       }
 
-      for (i in 1:length(pivotDefinitions)) {
+      for (i in seq_along(pivotDefinitions)) {
         file.copy(
           from = pivotDefinitions[i],
           to = file.path(pivotCacheDir, sprintf("pivotCacheDefinition%s.xml", i)),
@@ -733,7 +733,7 @@ Workbook$methods(
         )
       }
 
-      for (i in 1:length(pivotRecords)) {
+      for (i in seq_along(pivotRecords)) {
         file.copy(
           from = pivotRecords[i],
           to = file.path(pivotCacheDir, sprintf("pivotCacheRecords%s.xml", i)),
@@ -742,7 +742,7 @@ Workbook$methods(
         )
       }
 
-      for (i in 1:length(pivotDefinitionsRels)) {
+      for (i in seq_along(pivotDefinitionsRels)) {
         file.copy(
           from = pivotDefinitionsRels[i],
           to = file.path(
@@ -754,7 +754,7 @@ Workbook$methods(
         )
       }
 
-      for (i in 1:length(pivotTables.xml.rels)) {
+      for (i in seq_along(pivotTables.xml.rels)) {
         write_file(
           body = pivotTables.xml.rels[[i]],
           fl = file.path(pivotTablesRelsDir, sprintf("pivotTable%s.xml.rels", i))
@@ -770,7 +770,7 @@ Workbook$methods(
       slicerCachesDir <- file.path(tmpDir, "xl", "slicerCaches")
       dir.create(path = slicerCachesDir, recursive = TRUE)
 
-      for (i in 1:length(slicers)) {
+      for (i in seq_along(slicers)) {
         if (nchar(slicers[i]) > 0) {
           file.copy(from = slicers[i], to = file.path(slicersDir, sprintf("slicer%s.xml", i)))
         }
@@ -778,7 +778,7 @@ Workbook$methods(
 
 
 
-      for (i in 1:length(slicerCaches)) {
+      for (i in seq_along(slicerCaches)) {
         write_file(
           body = slicerCaches[[i]],
           fl = file.path(slicerCachesDir, sprintf("slicerCache%s.xml", i))
@@ -826,7 +826,7 @@ Workbook$methods(
 
     ## write tables
     if (length(unlist(tables, use.names = FALSE)) > 0) {
-      for (i in 1:length(unlist(tables, use.names = FALSE))) {
+      for (i in seq_along(unlist(tables, use.names = FALSE))) {
         if (!grepl("openxlsx_deleted", attr(tables, "tableName")[i], fixed = TRUE)) {
           write_file(
             body = pxml(unlist(tables, use.names = FALSE)[[i]]),
@@ -848,7 +848,7 @@ Workbook$methods(
       xlqueryTablesDir <- file.path(tmpDir, "xl", "queryTables")
       dir.create(path = xlqueryTablesDir, recursive = TRUE)
 
-      for (i in 1:length(queryTables)) {
+      for (i in seq_along(queryTables)) {
         write_file(
           body = queryTables[[i]],
           fl = file.path(xlqueryTablesDir, sprintf("queryTable%s.xml", i))
@@ -866,7 +866,7 @@ Workbook$methods(
       externalLinksDir <- file.path(tmpDir, "xl", "externalLinks")
       dir.create(path = externalLinksDir, recursive = TRUE)
 
-      for (i in 1:length(externalLinks)) {
+      for (i in seq_along(externalLinks)) {
         write_file(
           body = externalLinks[[i]],
           fl = file.path(externalLinksDir, sprintf("externalLink%s.xml", i))
@@ -880,7 +880,7 @@ Workbook$methods(
         file.path(tmpDir, "xl", "externalLinks", "_rels")
       dir.create(path = externalLinksRelsDir, recursive = TRUE)
 
-      for (i in 1:length(externalLinksRels)) {
+      for (i in seq_along(externalLinksRels)) {
         write_file(
           body = externalLinksRels[[i]],
           fl = file.path(
@@ -1231,7 +1231,7 @@ Workbook$methods(
 
 Workbook$methods(
   writeDrawingVML = function(dir) {
-    for (i in 1:length(comments)) {
+    for (i in seq_along(comments)) {
       id <- 1025
 
       cd <- unlist(lapply(comments[[i]], "[[", "clientData"))
@@ -1671,7 +1671,7 @@ Workbook$methods(
         fontNode <- stri_join(fontNode, sprintf(
           "<color %s/>",
           stri_join(
-            sapply(1:length(style$fontColour), function(i) {
+            sapply(seq_along(style$fontColour), function(i) {
               sprintf('%s="%s"', names(style$fontColour)[i], style$fontColour[i])
             }),
             sep = " ",
@@ -2067,10 +2067,10 @@ Workbook$methods(
         if (length(worksheets_rels[[i]]) > 0) {
           ws_rels <- worksheets_rels[[i]]
           if (hasHL) {
-            h_inds <- stri_join(1:length(worksheets[[i]]$hyperlinks), "h")
+            h_inds <- stri_join(seq_along(worksheets[[i]]$hyperlinks), "h")
             ws_rels <-
               c(ws_rels, unlist(
-                lapply(1:length(h_inds), function(j) {
+                lapply(seq_along(h_inds), function(j) {
                   worksheets[[i]]$hyperlinks[[j]]$to_target_xml(h_inds[j])
                 })
               ))
@@ -2495,7 +2495,7 @@ Workbook$methods(
     }
 
     form <-
-      sapply(1:length(value), function(i) {
+      sapply(seq_along(value), function(i) {
         sprintf("<formula%s>%s</formula%s>", i, value[i], i)
       })
     worksheets[[sheet]]$dataValidations <<-
@@ -3073,7 +3073,7 @@ Workbook$methods(
     ## Steps
     # Order workbook.xml.rels:
     #   sheets -> style -> theme -> sharedStrings -> tables -> calcChain
-    # Assign workbook.xml.rels children rIds, 1:length(workbook.xml.rels)
+    # Assign workbook.xml.rels children rIds, seq_along(workbook.xml.rels)
     # Assign workbook$sheets rIds 1:nSheets
     #
     ## drawings will always be r:id1 on worksheet
@@ -3146,7 +3146,7 @@ Workbook$methods(
 
     ## Re assign rIds to children of workbook.xml.rels
     workbook.xml.rels <<-
-      unlist(lapply(1:length(workbook.xml.rels), function(i) {
+      unlist(lapply(seq_along(workbook.xml.rels), function(i) {
         gsub('(?<=Relationship Id="rId)[0-9]+',
           i,
           workbook.xml.rels[[i]],
@@ -3171,7 +3171,7 @@ Workbook$methods(
 
     ## Reassign rId to workbook sheet elements, (order sheets by sheetId first)
     workbook$sheets <<-
-      unlist(lapply(1:length(workbook$sheets), function(i) {
+      unlist(lapply(seq_along(workbook$sheets), function(i) {
         gsub('(?<= r:id="rId)[0-9]+', i, workbook$sheets[[i]], perl = TRUE)
       }))
 
@@ -3234,7 +3234,7 @@ Workbook$methods(
           )
         ))
 
-      for (i in 1:length(workbook$definedNames)) {
+      for (i in seq_along(workbook$definedNames)) {
         if (!is.na(newId[i])) {
           workbook$definedNames[[i]] <<-
             gsub(
@@ -3252,7 +3252,7 @@ Workbook$methods(
 
     ## update workbook r:id to match reordered workbook.xml.rels externalLink element
     if (length(extRefInds) > 0) {
-      newInds <- as.integer(1:length(extRefInds) + length(sheetInds))
+      newInds <- as.integer(seq_along(extRefInds) + length(sheetInds))
       workbook$externalReferences <<-
         stri_join(
           "<externalReferences>",
@@ -3337,7 +3337,7 @@ Workbook$methods(
 
 
     ## Make sure all rowHeights have rows, if not append them!
-    for (i in 1:length(worksheets)) {
+    for (i in seq_along(worksheets)) {
       if (length(rowHeights[[i]]) > 0) {
         rh <- as.integer(names(rowHeights[[i]]))
         missing_rows <- rh[!rh %in% worksheets[[i]]$sheet_data$rows]

--- a/R/helperFunctions.R
+++ b/R/helperFunctions.R
@@ -257,7 +257,7 @@ classStyles <- function(wb, sheet, startRow, startCol, colNames, nRow, colClasse
 
   if (!is.null(newStylesElements)) {
     if (stack) {
-      for (i in 1:length(newStylesElements)) {
+      for (i in seq_along(newStylesElements)) {
         wb$addStyle(
           sheet = sheet,
           style = newStylesElements[[i]]$style,
@@ -350,11 +350,11 @@ writeCommentXML <- function(comment_list, file_name) {
   xml <- c(xml, paste0("<authors>", paste(sprintf("<author>%s</author>", authors), collapse = ""), "</authors><commentList>"))
 
 
-  for (i in 1:length(comment_list)) {
+  for (i in seq_along(comment_list)) {
     authorInd <- which(authors == comment_list[[i]]$author) - 1L
     xml <- c(xml, sprintf('<comment ref="%s" authorId="%s" shapeId="0"><text>', comment_list[[i]]$ref, authorInd))
 
-    for (j in 1:length(comment_list[[i]]$comment)) {
+    for (j in seq_along(comment_list[[i]]$comment)) {
       xml <- c(xml, sprintf('<r>%s<t xml:space="preserve">%s</t></r>', comment_list[[i]]$style[[j]], comment_list[[i]]$comment[[j]]))
     }
 
@@ -445,7 +445,7 @@ getAttrsFont <- function(xml, tag) {
     Encoding(x) <- "UTF-8"
     x
   })
-  vals <- lapply(1:length(vals), function(i) {
+  vals <- lapply(seq_along(vals), function(i) {
     names(vals[[i]]) <- nms[[i]]
     vals[[i]]
   })
@@ -483,7 +483,7 @@ buildFontList <- function(fonts) {
 
   ## Build font objects
   ft <- replicate(list(), n = length(fonts))
-  for (i in 1:length(fonts)) {
+  for (i in seq_along(fonts)) {
     f <- NULL
     nms <- NULL
     if (length(unlist(sz[i])) > 0) {
@@ -526,7 +526,7 @@ buildFontList <- function(fonts) {
       nms <- c(nms, "underline")
     }
 
-    f <- lapply(1:length(f), function(i) unlist(f[i]))
+    f <- lapply(seq_along(f), function(i) unlist(f[i]))
     names(f) <- nms
 
     ft[[i]] <- f
@@ -581,7 +581,7 @@ nodeAttributes <- function(x) {
   attrs <- lapply(attrs, gsub, pattern = '"', replacement = "")
 
   attrs <- lapply(attrs, strsplit, split = "=")
-  for (i in 1:length(attrs)) {
+  for (i in seq_along(attrs)) {
     nms <- lapply(attrs[[i]], "[[", 1)
     vals <- lapply(attrs[[i]], "[[", 2)
     a <- unlist(vals)
@@ -613,7 +613,7 @@ buildBorder <- function(x) {
 
   sides <- c("TOP", "BOTTOM", "LEFT", "RIGHT", "DIAGONAL")
   sideBorder <- character(length = length(x))
-  for (i in 1:length(x)) {
+  for (i in seq_along(x)) {
     tmp <- sides[sapply(sides, function(s) grepl(s, x[[i]], ignore.case = TRUE))]
     if (length(tmp) > 1) tmp <- tmp[[1]]
     if (length(tmp) == 1) {
@@ -825,7 +825,7 @@ mergeCell2mapping <- function(x) {
   })
 
   ## for each we grid.expand
-  refs <- do.call("rbind", lapply(1:length(rows), function(i) {
+  refs <- do.call("rbind", lapply(seq_along(rows), function(i) {
     tmp <- expand.grid("cols" = cols[[i]], "rows" = rows[[i]])
     tmp$ref <- paste0(convert_to_excel_ref(cols = tmp$cols, LETTERS = LETTERS), tmp$rows)
     tmp$anchor_cell <- tmp$ref[1]
@@ -845,7 +845,7 @@ splitHeaderFooter <- function(x) {
   tmp <- gsub("<(/|)(odd|even|first)(Header|Footer)>(&amp;|)", "", x, perl = TRUE)
   special_tags <- regmatches(tmp, regexpr("&amp;[^LCR]", tmp))
   if (length(special_tags) > 0) {
-    for (i in 1:length(special_tags)) {
+    for (i in seq_along(special_tags)) {
       tmp <- gsub(special_tags[i], sprintf("openxlsx__%s67298679", i), tmp, fixed = TRUE)
     }
   }
@@ -853,7 +853,7 @@ splitHeaderFooter <- function(x) {
   tmp <- strsplit(tmp, split = "&amp;")[[1]]
 
   if (length(special_tags) > 0) {
-    for (i in 1:length(special_tags)) {
+    for (i in seq_along(special_tags)) {
       tmp <- gsub(sprintf("openxlsx__%s67298679", i), special_tags[i], tmp, fixed = TRUE)
     }
   }

--- a/R/loadWorkbook.R
+++ b/R/loadWorkbook.R
@@ -173,7 +173,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
 
     ## add worksheets to wb
     j <- 1
-    for (i in 1:length(sheetrId)) {
+    for (i in seq_along(sheetrId)) {
       if (is_chart_sheet[i]) {
         count <- 0
         txt <- paste(readUTF8(chartSheetsXML[j]), collapse = "")
@@ -304,31 +304,31 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
 
 
     if (length(pivotTableXML) > 0) {
-      wb$pivotTables[1:length(pivotTableXML)] <- pivotTableXML
+      wb$pivotTables[seq_along(pivotTableXML)] <- pivotTableXML
       pivot_content_type <- c(
         pivot_content_type,
-        sprintf('<Override PartName="/xl/pivotTables/pivotTable%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotTable+xml"/>', 1:length(pivotTableXML))
+        sprintf('<Override PartName="/xl/pivotTables/pivotTable%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotTable+xml"/>', seq_along(pivotTableXML))
       )
     }
 
     if (length(pivotDefXML) > 0) {
-      wb$pivotDefinitions[1:length(pivotDefXML)] <- pivotDefXML
+      wb$pivotDefinitions[seq_along(pivotDefXML)] <- pivotDefXML
       pivot_content_type <- c(
         pivot_content_type,
-        sprintf('<Override PartName="/xl/pivotCache/pivotCacheDefinition%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/>', 1:length(pivotDefXML))
+        sprintf('<Override PartName="/xl/pivotCache/pivotCacheDefinition%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/>', seq_along(pivotDefXML))
       )
     }
 
     if (length(pivotCacheRecords) > 0) {
-      wb$pivotRecords[1:length(pivotCacheRecords)] <- pivotCacheRecords
+      wb$pivotRecords[seq_along(pivotCacheRecords)] <- pivotCacheRecords
       pivot_content_type <- c(
         pivot_content_type,
-        sprintf('<Override PartName="/xl/pivotCache/pivotCacheRecords%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheRecords+xml"/>', 1:length(pivotCacheRecords))
+        sprintf('<Override PartName="/xl/pivotCache/pivotCacheRecords%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheRecords+xml"/>', seq_along(pivotCacheRecords))
       )
     }
 
     if (length(pivotDefRelsXML) > 0) {
-      wb$pivotDefinitionsRels[1:length(pivotDefRelsXML)] <- pivotDefRelsXML
+      wb$pivotDefinitionsRels[seq_along(pivotDefRelsXML)] <- pivotDefRelsXML
     }
 
 
@@ -341,13 +341,13 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
     ## workbook rels
     wb$workbook.xml.rels <- c(
       wb$workbook.xml.rels,
-      sprintf('<Relationship Id="rId%s" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition" Target="pivotCache/pivotCacheDefinition%s.xml"/>', rIds, 1:length(pivotDefXML))
+      sprintf('<Relationship Id="rId%s" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition" Target="pivotCache/pivotCacheDefinition%s.xml"/>', rIds, seq_along(pivotDefXML))
     )
 
 
     caches <- getNodes(xml = workbook, tagIn = "<pivotCaches>")
     caches <- getChildlessNode(xml = caches, tag = "<pivotCache ")
-    for (i in 1:length(caches)) {
+    for (i in seq_along(caches)) {
       caches[i] <- gsub('"rId[0-9]+"', sprintf('"rId%s"', rIds[i]), caches[i])
     }
 
@@ -429,12 +429,12 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
 
     wb$Content_Types <- c(
       wb$Content_Types,
-      sprintf('<Override PartName="/xl/externalLinks/externalLink%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml"/>', 1:length(extLinksXML))
+      sprintf('<Override PartName="/xl/externalLinks/externalLink%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml"/>', seq_along(extLinksXML))
     )
 
     wb$workbook.xml.rels <- c(wb$workbook.xml.rels, sprintf(
       '<Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLink" Target="externalLinks/externalLink1.xml"/>',
-      1:length(extLinksXML)
+      seq_along(extLinksXML)
     ))
   }
 
@@ -465,7 +465,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
   if (length(wb$styleObjects) > 0) {
     style_names <- sapply(wb$styleObjects, "[[", "sheet")
     Encoding(style_names) <- "UTF-8"
-    wb$styleObjects <- lapply(1:length(style_names), function(i) {
+    wb$styleObjects <- lapply(seq_along(style_names), function(i) {
       wb$styleObjects[[i]]$sheet <- style_names[[i]]
       wb$styleObjects[[i]]
     })
@@ -473,7 +473,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
 
 
   ## Fix headers/footers
-  for (i in 1:length(worksheetsXML)) {
+  for (i in seq_along(worksheetsXML)) {
     if (!is_chart_sheet[i]) {
       if (length(wb$worksheets[[i]]$headerFooter) > 0) {
         wb$worksheets[[i]]$headerFooter <- lapply(wb$worksheets[[i]]$headerFooter, splitHeaderFooter)
@@ -519,7 +519,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
     ## sheet.xml have been reordered to be in the order of sheetrId
     ## not every sheet has a worksheet rels
 
-    xml <- lapply(1:length(allRels), function(i) {
+    xml <- lapply(seq_along(allRels), function(i) {
       if (haveRels[i]) {
         xml <- readUTF8(allRels[[i]])
         xml <- removeHeadTag(xml)
@@ -585,7 +585,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
     if (length(slicerCachesXML) > 0) {
 
       ## ---- slicerCaches
-      inds <- 1:length(slicerCachesXML)
+      inds <- seq_along(slicerCachesXML)
       wb$Content_Types <- c(wb$Content_Types, sprintf('<Override PartName="/xl/slicerCaches/slicerCache%s.xml" ContentType="application/vnd.ms-excel.slicerCache+xml"/>', inds))
       wb$slicerCaches <- sapply(slicerCachesXML[order(nchar(slicerCachesXML), slicerCachesXML)], function(x) removeHeadTag(cppReadFile(x)))
       wb$workbook.xml.rels <- c(wb$workbook.xml.rels, sprintf('<Relationship Id="rId%s" Type="http://schemas.microsoft.com/office/2007/relationships/slicerCache" Target="slicerCaches/slicerCache%s.xml"/>', 1E5 + inds, inds))
@@ -598,14 +598,14 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
 
     if (length(tablesXML) > 0) {
       tables <- lapply(xml, function(x) as.integer(regmatches(x, regexpr("(?<=table)[0-9]+(?=\\.xml)", x, perl = TRUE))))
-      tableSheets <- unlist(lapply(1:length(sheetrId), function(i) rep(i, length(tables[[i]]))))
+      tableSheets <- unlist(lapply(seq_along(sheetrId), function(i) rep(i, length(tables[[i]]))))
 
       if (length(unlist(tables)) > 0) {
         ## get the tables that belong to each worksheet and create a worksheets_rels for each
         tCount <- 2L ## table r:Ids start at 3
-        for (i in 1:length(tables)) {
+        for (i in seq_along(tables)) {
           if (length(tables[[i]]) > 0) {
-            k <- 1:length(tables[[i]]) + tCount
+            k <- seq_along(tables[[i]]) + tCount
             wb$worksheets_rels[[i]] <- unlist(c(
               wb$worksheets_rels[[i]],
               sprintf('<Relationship Id="rId%s" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/table" Target="../tables/table%s.xml"/>', k, k)
@@ -628,23 +628,23 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
         refs <- regmatches(wb$tables, regexpr('(?<=ref=")[0-9A-Z:]+', wb$tables, perl = TRUE))
         names(wb$tables) <- refs
 
-        wb$Content_Types <- c(wb$Content_Types, sprintf('<Override PartName="/xl/tables/table%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml"/>', 1:length(wb$tables) + 2))
+        wb$Content_Types <- c(wb$Content_Types, sprintf('<Override PartName="/xl/tables/table%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml"/>', seq_along(wb$tables) + 2))
 
         ## relabel ids
-        for (i in 1:length(wb$tables)) {
+        for (i in seq_along(wb$tables)) {
           newId <- sprintf(' id="%s" ', i + 2)
           wb$tables[[i]] <- sub(' id="[0-9]+" ', newId, wb$tables[[i]])
         }
 
         displayNames <- unlist(regmatches(wb$tables, regexpr('(?<=displayName=").*?[^"]+', wb$tables, perl = TRUE)))
         if (length(displayNames) != length(tablesXML)) {
-          displayNames <- paste0("Table", 1:length(tablesXML))
+          displayNames <- paste0("Table", seq_along(tablesXML))
         }
 
         attr(wb$tables, "sheet") <- tableSheets
         attr(wb$tables, "tableName") <- displayNames
 
-        for (i in 1:length(tableSheets)) {
+        for (i in seq_along(tableSheets)) {
           table_sheet_i <- tableSheets[i]
           attr(wb$worksheets[[table_sheet_i]]$tableParts, "tableName") <- c(attr(wb$worksheets[[table_sheet_i]]$tableParts, "tableName"), displayNames[i])
         }
@@ -712,7 +712,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
 
     ## loop over all worksheets and assign drawing to sheet
     if (any(hasDrawing)) {
-      for (i in 1:length(xml)) {
+      for (i in seq_along(xml)) {
         if (hasDrawing[i]) {
           target <- unlist(lapply(drawXMLrelationship[[i]], function(x) regmatches(x, gregexpr('(?<=Target=").*?"', x, perl = TRUE))[[1]]))
           target <- basename(gsub('"$', "", target))
@@ -746,7 +746,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
 
       ## loop over all worksheets and assign drawing to sheet
       if (any(hasDrawing)) {
-        for (i in 1:length(xml)) {
+        for (i in seq_along(xml)) {
           if (hasDrawing[i]) {
             target <- unlist(lapply(drawXMLrelationship[[i]], function(x) regmatches(x, gregexpr('(?<=Target=").*?"', x, perl = TRUE))[[1]]))
             target <- basename(gsub('"$', "", target))
@@ -785,7 +785,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
       commentXMLrelationship <- lapply(xml, function(x) x[grepl("comments[0-9]+\\.xml", x)])
       hasComment <- sapply(commentXMLrelationship, length) > 0 ## which sheets have a comment
 
-      for (i in 1:length(xml)) {
+      for (i in seq_along(xml)) {
         if (hasComment[i]) {
           target <- unlist(lapply(drawXMLrelationship[[i]], function(x) regmatches(x, gregexpr('(?<=Target=").*?"', x, perl = TRUE))[[1]]))
           target <- basename(gsub('"$', "", target))
@@ -825,7 +825,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
             comments <- lapply(comments, function(x) gsub(".*?>", "", x, perl = TRUE))
 
 
-            wb$comments[[i]] <- lapply(1:length(comments), function(j) {
+            wb$comments[[i]] <- lapply(seq_along(comments), function(j) {
               comment_list <- list(
                 "ref" = refs[j],
                 "author" = authors[j],
@@ -843,11 +843,11 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
     drawXMLrelationship <- lapply(xml, function(x) x[grepl("relationships/image", x)])
     hasDrawing <- sapply(drawXMLrelationship, length) > 0 ## which sheets have a drawing
     if (any(hasDrawing)) {
-      for (i in 1:length(xml)) {
+      for (i in seq_along(xml)) {
         if (hasDrawing[i]) {
           image_ids <- unlist(getId(drawXMLrelationship[[i]]))
-          new_image_ids <- paste0("rId", 1:length(image_ids) + 70000)
-          for (j in 1:length(image_ids)) {
+          new_image_ids <- paste0("rId", seq_along(image_ids) + 70000)
+          for (j in seq_along(image_ids)) {
             wb$worksheets[[i]]$oleObjects <- gsub(image_ids[j], new_image_ids[j], wb$worksheets[[i]]$oleObjects, fixed = TRUE)
             wb$worksheets_rels[[i]] <- c(wb$worksheets_rels[[i]], gsub(image_ids[j], new_image_ids[j], drawXMLrelationship[[i]][j], fixed = TRUE))
           }
@@ -859,11 +859,11 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
     drawXMLrelationship <- lapply(xml, function(x) x[grepl("relationships/package", x)])
     hasDrawing <- sapply(drawXMLrelationship, length) > 0 ## which sheets have a drawing
     if (any(hasDrawing)) {
-      for (i in 1:length(xml)) {
+      for (i in seq_along(xml)) {
         if (hasDrawing[i]) {
           image_ids <- unlist(getId(drawXMLrelationship[[i]]))
-          new_image_ids <- paste0("rId", 1:length(image_ids) + 90000)
-          for (j in 1:length(image_ids)) {
+          new_image_ids <- paste0("rId", seq_along(image_ids) + 90000)
+          for (j in seq_along(image_ids)) {
             wb$worksheets[[i]]$oleObjects <- gsub(image_ids[j], new_image_ids[j], wb$worksheets[[i]]$oleObjects, fixed = TRUE)
             wb$worksheets_rels[[i]] <- c(
               wb$worksheets_rels[[i]],
@@ -896,9 +896,9 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
       hasPivot <- sapply(pivotRels, length) > 0
 
       ## Modify rIds
-      for (i in 1:length(pivotRels)) {
+      for (i in seq_along(pivotRels)) {
         if (hasPivot[i]) {
-          for (j in 1:length(pivotRels[[i]])) {
+          for (j in seq_along(pivotRels[[i]])) {
             pivotRels[[i]][j] <- gsub('"rId[0-9]+"', sprintf('"rId%s"', 20000L + j), pivotRels[[i]][j])
           }
 
@@ -908,7 +908,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
 
 
       ## remove any workbook_res references to pivot tables that are not being used in worksheet_rels
-      inds <- 1:length(wb$pivotTables.xml.rels)
+      inds <- seq_along(wb$pivotTables.xml.rels)
       fileNo <- as.integer(unlist(regmatches(unlist(wb$worksheets_rels), gregexpr("(?<=pivotTable)[0-9]+(?=\\.xml)", unlist(wb$worksheets_rels), perl = TRUE))))
       inds <- inds[!inds %in% fileNo]
 
@@ -936,7 +936,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
     wb$queryTables <- unlist(lapply(queryTablesXML[order(ids)], function(x) removeHeadTag(cppReadFile(xmlFile = x))))
     wb$Content_Types <- c(
       wb$Content_Types,
-      sprintf('<Override PartName="/xl/queryTables/queryTable%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.queryTable+xml"/>', 1:length(queryTablesXML))
+      sprintf('<Override PartName="/xl/queryTables/queryTable%s.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.queryTable+xml"/>', seq_along(queryTablesXML))
     )
   }
 

--- a/R/readWorkbook.R
+++ b/R/readWorkbook.R
@@ -535,7 +535,7 @@ read.xlsx.default <- function(xlsxFile,
     isDate <- (s %in% dateStyleIds)
 
     ## set to false if in string_refs
-    isDate[1:length(s) %in% string_refs] <- FALSE
+    isDate[seq_along(s) %in% string_refs] <- FALSE
 
     # check numbers are also integers
     not_an_integer <- numeric(length(v))

--- a/inst/extdata/build_font_size_lookup.R
+++ b/inst/extdata/build_font_size_lookup.R
@@ -15,7 +15,7 @@ font <- tolower(gsub(" ", ".", gsub("\\.xlsx", "", files2)))
 strs <- "openxlsxFontSizeLookupTable <- \ndata.frame("
 allWidths <- rep(8.43, 29)
 names(allWidths) <- 1:29
-for(i in 1:length(files)){
+for(i in seq_along(files)){
   
   f <- font[[i]]
   widths <- round(as.numeric(read.xlsx(files[[i]])[2,]), 6)
@@ -42,7 +42,7 @@ font <- tolower(gsub(" ", ".", gsub("\\-bold.xlsx", "", files2)))
 strsBold <- "openxlsxFontSizeLookupTableBold <- \ndata.frame("
 allWidths <- rep(8.43, 29)
 names(allWidths) <- 1:29
-for(i in 1:length(files)){
+for(i in seq_along(files)){
   
   f <- font[[i]]
   widths <- round(as.numeric(read.xlsx(files[[i]])[2,]), 6)


### PR DESCRIPTION
IMHO, `seq_along()` is better than `1:length()` as the latter will cause unexpected results when `x` is length zero. 

In addition, it's faster.

```r
x <- character()
1:length(x)
#> [1] 1 0
seq_along(x)
#> integer(0)
```