### PR TITLE
bug fix: fillMergedCells and rows now work as expected

### DIFF
--- a/src/read_workbook.cpp
+++ b/src/read_workbook.cpp
@@ -157,8 +157,8 @@ List getCellInfo(std::string xmlFile,
   // file.open(xmlFile.c_str());
   // while (file >> buf)
   // xml += buf + ' ';
-  std::string xml = read_file_newline(xmlFile);
-  
+  std::string xml = read_file_newline(xmlFile);  
+  std::string xml2 = "";
   std::string rtag = "r=";
   std::string ttag = " t=";
   std::string stag = " s=";
@@ -182,6 +182,7 @@ List getCellInfo(std::string xmlFile,
   }
   
   xml = xml.substr(pos + 11);     // get from "sheedData" to the end
+  xml2 = xml;
   
   // startRow cut off
   int row_i = 0;
@@ -275,7 +276,7 @@ List getCellInfo(std::string xmlFile,
   }
   
   // pull out cell merges
-  CharacterVector merge_cell_xml = getChildlessNode(xml, "<mergeCell ");
+  CharacterVector merge_cell_xml = getChildlessNode(xml2, "<mergeCell ");
   
   
   CharacterVector r(ocs);

--- a/tests/testthat/test-fill_merged_cells.R
+++ b/tests/testthat/test-fill_merged_cells.R
@@ -14,12 +14,31 @@ test_that("fill merged cells", {
   writeData(wb = wb, sheet = 1, x = 2, startRow = 2, startCol = 2)
   writeData(wb = wb, sheet = 1, x = 3, startRow = 2, startCol = 3)
   writeData(wb = wb, sheet = 1, x = 4, startRow = 2, startCol = 4)
+  writeData(wb = wb, sheet = 1, x = t(matrix(1:4, 4, 4)), startRow = 3, startCol = 1, colNames = FALSE)
 
   mergeCells(wb = wb, sheet = 1, cols = 2:4, rows = 1)
+  mergeCells(wb = wb, sheet = 1, cols = 2:4, rows = 3)
+  mergeCells(wb = wb, sheet = 1, cols = 2:4, rows = 4)
+  mergeCells(wb = wb, sheet = 1, cols = 2:4, rows = 5)
 
   tmp_file <- tempfile(fileext = ".xlsx")
   saveWorkbook(wb = wb, file = tmp_file, overwrite = TRUE)
 
   expect_equal(names(read.xlsx(tmp_file, fillMergedCells = FALSE)), c("A", "B", "X3", "X4"))
   expect_equal(names(read.xlsx(tmp_file, fillMergedCells = TRUE)), c("A", "B", "B", "B"))
+  
+  r1 <- data.frame("A" = rep(1, 5), "B" = rep(2, 5), "X3" = rep(3,5), "X4" = rep(4, 5))
+  r2 <- data.frame("A" = rep(1, 5), "B" = rep(2, 5), "B1" = c(3,2,2,2,3), "B2" = c(4,2,2,2,4))
+  names(r2) <- c("A", "B", "B", "B")
+  
+  r2_1 <- r2[1:5, 1:3]
+  names(r2_1) <- c("A", "B", "B")
+  
+  expect_equal(read.xlsx(tmp_file, fillMergedCells = FALSE), r1)
+  expect_equal(read.xlsx(tmp_file, fillMergedCells = TRUE), r2)
+  
+  expect_equal( read.xlsx(tmp_file, cols = 1:3, fillMergedCells = TRUE), r2_1)
+  expect_equal( read.xlsx(tmp_file, rows = 1:3, fillMergedCells = TRUE), r2[1:2, ])
+  expect_equal( read.xlsx(tmp_file, cols = 1:3, rows = 1:4, fillMergedCells = TRUE), r2_1[1:3,])
+  
 })


### PR DESCRIPTION
This closes a bug spotted by @sjewo over at https://github.com/awalker89/openxlsx/issues/225

Previously once `read.xlsx(filename, rows = ...)` was selected `fillMergedCells` no longer worked.

The issue is in `getCellInfo` `std::string xml` is overwritten if rows are selected and `merge_cell_xml` returned a `character(0)`