### PR TITLE
[WIP] improve getChildlessNode. fixes #127

### DIFF
--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -17859,7 +17859,7 @@ Workbook$methods(
 
 
     ## Number formats
-    numFmts <- getChildlessNode(xml = stylesTxt, tag = "<numFmt ")
+    numFmts <- getChildlessNode(xml = stylesTxt, tag = "numFmt")
     numFmtFlag <- FALSE
     if (length(numFmts) > 0) {
       numFmtsIds <-
@@ -17907,7 +17907,7 @@ Workbook$methods(
 
     cellXfs <- getNodes(xml = stylesTxt, tagIn = "<cellXfs")
 
-    xf <- getChildlessNode(xml = cellXfs, tag = "<xf ")
+    xf <- getChildlessNode(xml = cellXfs, tag = "xf")
     xfAttrs <- regmatches(xf, gregexpr('[a-zA-Z]+=".*?"', xf))
     xfNames <-
       lapply(xfAttrs, function(xfAttrs) {

--- a/R/helperFunctions.R
+++ b/R/helperFunctions.R
@@ -477,9 +477,9 @@ buildFontList <- function(fonts) {
   family <- getAttrs(fonts, "<family ")
   scheme <- getAttrs(fonts, "<scheme ")
 
-  italic <- lapply(fonts, getChildlessNode, tag = "<i")
-  bold <- lapply(fonts, getChildlessNode, tag = "<b")
-  underline <- lapply(fonts, getChildlessNode, tag = "<u")
+  italic <- lapply(fonts, getChildlessNode, tag = "i")
+  bold <- lapply(fonts, getChildlessNode, tag = "b")
+  underline <- lapply(fonts, getChildlessNode, tag = "u")
 
   ## Build font objects
   ft <- replicate(list(), n = length(fonts))
@@ -634,7 +634,7 @@ buildBorder <- function(x) {
 
   ## Colours
   cols <- replicate(n = length(sideBorder), list(rgb = "FF000000"))
-  colNodes <- unlist(sapply(x, getChildlessNode, tag = "<color", USE.NAMES = FALSE))
+  colNodes <- unlist(sapply(x, getChildlessNode, tag = "color", USE.NAMES = FALSE))
 
   if (length(colNodes) > 0) {
     attrs <- regmatches(colNodes, regexpr('(theme|indexed|rgb|auto)=".+"', colNodes))

--- a/R/loadWorkbook.R
+++ b/R/loadWorkbook.R
@@ -116,7 +116,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
   workbookRelsXML <- xmlFiles[grepl("workbook.xml.rels$", xmlFiles, perl = TRUE)]
   if (length(workbookRelsXML) > 0) {
     workbookRelsXML <- paste(readUTF8(workbookRelsXML), collapse = "")
-    workbookRelsXML <- getChildlessNode(xml = workbookRelsXML, tag = "<Relationship ")
+    workbookRelsXML <- getChildlessNode(xml = workbookRelsXML, tag = "Relationship")
     worksheet_rId_mapping <- workbookRelsXML[grepl("worksheets/sheet", workbookRelsXML, fixed = TRUE)]
   }
 
@@ -183,7 +183,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
           zoom <- 100
         }
 
-        tabColour <- getChildlessNode(xml = txt, tag = "<tabColor ")
+        tabColour <- getChildlessNode(xml = txt, tag = "tabColor")
         if (length(tabColour) == 0) {
           tabColour <- NULL
         }
@@ -204,18 +204,18 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
 
 
     ## additional workbook attributes
-    calcPr <- getChildlessNode(xml = workbook, tag = "<calcPr ")
+    calcPr <- getChildlessNode(xml = workbook, tag = "calcPr")
     if (length(calcPr) > 0) {
       wb$workbook$calcPr <- calcPr
     }
 
 
-    workbookPr <- getChildlessNode(xml = workbook, tag = "<workbookPr ")
+    workbookPr <- getChildlessNode(xml = workbook, tag = "workbookPr")
     if (length(workbookPr) > 0) {
       wb$workbook$workbookPr <- workbookPr
     }
 
-    workbookProtection <- getChildlessNode(xml = workbook, tag = "<workbookProtection ")
+    workbookProtection <- getChildlessNode(xml = workbook, tag = "workbookProtection")
     if (length(workbookProtection) > 0) {
       wb$workbook$workbookProtection <- workbookProtection
     }
@@ -346,7 +346,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
 
 
     caches <- getNodes(xml = workbook, tagIn = "<pivotCaches>")
-    caches <- getChildlessNode(xml = caches, tag = "<pivotCache ")
+    caches <- getChildlessNode(xml = caches, tag = "pivotCache")
     for (i in seq_along(caches)) {
       caches[i] <- gsub('"rId[0-9]+"', sprintf('"rId%s"', rIds[i]), caches[i])
     }
@@ -525,7 +525,7 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
         xml <- removeHeadTag(xml)
         xml <- gsub("<Relationships .*?>", "", xml)
         xml <- gsub("</Relationships>", "", xml)
-        xml <- getChildlessNode(xml = xml, tag = "<Relationship ")
+        xml <- getChildlessNode(xml = xml, tag = "Relationship")
       } else {
         xml <- "<Relationship >"
       }

--- a/R/readWorkbook.R
+++ b/R/readWorkbook.R
@@ -176,7 +176,7 @@ read.xlsx.default <- function(xlsxFile,
       collapse = ""
     )
   workbookRelsXML <-
-    getChildlessNode(xml = workbookRelsXML, tag = "<Relationship ")
+    getChildlessNode(xml = workbookRelsXML, tag = "Relationship")
 
   workbook <-
     unlist(readUTF8(workbook))
@@ -528,7 +528,7 @@ read.xlsx.default <- function(xlsxFile,
     styles <- removeHeadTag(styles)
 
     ## Number formats
-    numFmts <- getChildlessNode(xml = styles, tag = "<numFmt ")
+    numFmts <- getChildlessNode(xml = styles, tag = "numFmt")
 
     dateIds <- NULL
     if (length(numFmts) > 0) {
@@ -549,7 +549,7 @@ read.xlsx.default <- function(xlsxFile,
 
     ## which styles are using these dateIds
     cellXfs <- getNodes(xml = styles, tagIn = "<cellXfs")
-    xf <- getChildlessNode(xml = cellXfs, tag = "<xf ")
+    xf <- getChildlessNode(xml = cellXfs, tag = "xf")
     lookingFor <-
       paste(sprintf('numFmtId="%s"', dateIds), collapse = "|")
     dateStyleIds <-

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -2803,7 +2803,7 @@ getNamedRegions.default <- function(x) {
   workbook <- xmlFiles[grepl("workbook.xml$", xmlFiles, perl = TRUE)]
   workbook <- unlist(readUTF8(workbook))
   
-  dn <- getChildlessNode(xml = removeHeadTag(workbook), tag = "<definedName ")
+  dn <- getChildlessNode(xml = removeHeadTag(workbook), tag = "definedName")
   if (length(dn) == 0) {
     return(NULL)
   }

--- a/src/load_workbook.cpp
+++ b/src/load_workbook.cpp
@@ -80,7 +80,7 @@ SEXP loadworksheets(Reference wb, List styleObjects, std::vector<std::string> xm
       }
       
       if(sheetPr.size() == 0)
-        sheetPr = getChildlessNode(xml_pre, "<sheetPr");
+        sheetPr = getChildlessNode(xml_pre, "sheetPr");
       
       if(sheetPr.size() > 0)
         this_worksheet.field("sheetPr") = sheetPr;
@@ -88,7 +88,7 @@ SEXP loadworksheets(Reference wb, List styleObjects, std::vector<std::string> xm
       
       
       // Freeze Panes
-      CharacterVector node_xml = getChildlessNode(xml_pre, "<pane ");
+      CharacterVector node_xml = getChildlessNode(xml_pre, "pane");
       if(node_xml.size() > 0)
         this_worksheet.field("freezePane") = node_xml;
       
@@ -211,28 +211,28 @@ SEXP loadworksheets(Reference wb, List styleObjects, std::vector<std::string> xm
       
       std::string xml_post = xml.substr(pos_post);
       
-      node_xml = getChildlessNode(xml_post, "<sheetProtection ");
+      node_xml = getChildlessNode(xml_post, "sheetProtection");
       if(node_xml.size() > 0) {
         this_worksheet.field("sheetProtection") = node_xml;
       }
       
       
-      node_xml = getChildlessNode(xml_post, "<autoFilter ");
+      node_xml = getChildlessNode(xml_post, "autoFilter");
       if(node_xml.size() > 0)
         this_worksheet.field("autoFilter") = node_xml;
       
       
-      node_xml = getChildlessNode(xml_post, "<hyperlink ");
+      node_xml = getChildlessNode(xml_post, "hyperlink");
       if(node_xml.size() > 0)
         this_worksheet.field("hyperlinks") = node_xml;
       
       
-      node_xml = getChildlessNode(xml_post, "<pageMargins ");
+      node_xml = getChildlessNode(xml_post, "pageMargins");
       if(node_xml.size() > 0)
         this_worksheet.field("pageMargins") = node_xml;
       
       
-      node_xml = getChildlessNode(xml_post, "<pageSetup ");
+      node_xml = getChildlessNode(xml_post, "pageSetup");
       if(node_xml.size() > 0){
         for(int j = 0; j < node_xml.size(); j++){
           
@@ -252,7 +252,7 @@ SEXP loadworksheets(Reference wb, List styleObjects, std::vector<std::string> xm
         this_worksheet.field("pageSetup") = node_xml;
       }
       
-      node_xml = getChildlessNode(xml_post, "<mergeCell ");
+      node_xml = getChildlessNode(xml_post, "mergeCell");
       if(node_xml.size() > 0)
         this_worksheet.field("mergeCells") = node_xml;
       
@@ -297,9 +297,9 @@ SEXP loadworksheets(Reference wb, List styleObjects, std::vector<std::string> xm
       }
       
       
-      node_xml = getChildlessNode(xml_post, "<drawing ");
+      node_xml = getChildlessNode(xml_post, "drawing");
       if(node_xml.size() == 0)
-        node_xml = getChildlessNode(xml_post, "<legacyDrawing ");
+        node_xml = getChildlessNode(xml_post, "legacyDrawing");
       
       if(node_xml.size() > 0){
         for(int j = 0; j < node_xml.size(); j++){

--- a/src/read_workbook.cpp
+++ b/src/read_workbook.cpp
@@ -276,7 +276,7 @@ List getCellInfo(std::string xmlFile,
   }
   
   // pull out cell merges
-  CharacterVector merge_cell_xml = getChildlessNode(xml2, "<mergeCell ");
+  CharacterVector merge_cell_xml = getChildlessNode(xml2, "mergeCell");
   
   
   CharacterVector r(ocs);


### PR DESCRIPTION
This pull request improves getChildlessNode. Previously it would only work flawlessly with `<foo bar/>` and not with `<foo><bar/></foo>`. The latter would read only `<foo><bar/>` resulting in incorrect xlsx files when written from a workbook.

```R
xml <- "<html is not a programming language><a ><b /></a><b /><a ></a><c /><yes it is a programming language>"
```

With this pull request it will be:

```R
> openxlsx:::getChildlessNode(xml, "a")
[1] "<a ><b /></a>" "<a ></a>"     
> openxlsx:::getChildlessNode(xml, "b")
[1] "<b />" "<b />"
> openxlsx:::getChildlessNode(xml, "c")
[1] "<c />"
``` 

Currently in master it is:

```R
> openxlsx:::getChildlessNode(xml, "<a")
[1] "<a ><b />"     "<a ></a><c />"
> openxlsx:::getChildlessNode(xml, "<b")
[1] "<b />" "<b />"
> openxlsx:::getChildlessNode(xml, "<c")
[1] "<c />"
```

This should be testet. In theory it should be slower than the current implementation, due to the initial check. It requires a few unit tests and the written xlsx files should be tested with Microsofts Excel since the issue does not arise with LibreOffice or R itself. I was able to run the unit tests prior to the completion of the syntax switch.