### PR TITLE
Top bottom conditional formatting

### DIFF
--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -2851,6 +2851,22 @@ Workbook$methods(
           formula[1],
           formula[2]
         )
+    } else if (type == "topN") {
+      cfRule <-
+        sprintf(
+          '<cfRule type="top10" dxfId="%s" priority="1" rank="%s" percent="%s"></cfRule>',
+          dxfId,
+          values[1],
+          values[2]
+        )
+    } else if (type == "bottomN") {
+      cfRule <-
+        sprintf(
+          '<cfRule type="top10" dxfId="%s" priority="1" rank="%s" percent="%s" bottom="1"></cfRule>',
+          dxfId,
+          values[1],
+          values[2]
+        )
     }
 
     worksheets[[sheet]]$conditionalFormatting <<-

--- a/R/conditional_formatting.R
+++ b/R/conditional_formatting.R
@@ -216,7 +216,7 @@
 #' writeData(wb, "databar", -5:5)
 #' conditionalFormatting(wb, "databar", cols = 1, rows = 1:11, type = "databar") ## Default colours
 #'
-#' ## Betweem
+#' ## Between
 #' # Highlight cells in interval [-2, 2]
 #' writeData(wb, "between", -5:5)
 #' conditionalFormatting(wb, "between", cols = 1, rows = 1:11, type = "between", rule = c(-2, 2))
@@ -240,7 +240,7 @@
 #'  style = negStyle, type = "topN", rank = 20, percent = TRUE)
 #'
 #' ## Logical Operators
-#' # You can use Excels logical Opertors
+#' # You can use Excels logical Operators
 #' writeData(wb, "logical operators", 1:10)
 #' conditionalFormatting(wb, "logical operators",
 #'   cols = 1, rows = 1:10,

--- a/man/conditionalFormatting.Rd
+++ b/man/conditionalFormatting.Rd
@@ -30,7 +30,7 @@ conditionalFormatting(
 \item{style}{A style to apply to those cells that satisfy the rule. Default is createStyle(fontColour = "#9C0006", bgFill = "#FFC7CE")}
 
 \item{type}{Either 'expression', 'colourScale', 'databar', 'duplicates', 'beginsWith', 
-'endsWith', 'contains' or 'notContains' (case insensitive).}
+'endsWith', 'topN', 'bottomN', 'contains' or 'notContains' (case insensitive).}
 
 \item{...}{See below}
 }
@@ -82,6 +82,30 @@ If type == "between"
   \item{style is a Style object. See \code{\link{createStyle}}}
   \item{rule is a numeric vector of length 2 specifying lower and upper bound (Inclusive)}
 }
+
+If type == "topN"
+\itemize{
+  \item{style is a Style object. See \code{\link{createStyle}}}
+  \item{rule is ignored}
+  \item{...
+  \itemize{
+    \item{\bold{rank} numeric vector of length 1 indicating number of highest values.}
+    \item{\bold{percent} TRUE if you want top N percentage.}
+     }
+   }
+}
+
+If type == "bottomN"
+\itemize{
+  \item{style is a Style object. See \code{\link{createStyle}}}
+  \item{rule is ignored}
+  \item{...
+  \itemize{
+    \item{\bold{rank} numeric vector of length 1 indicating number of lowest values.}
+    \item{\bold{percent} TRUE if you want bottom N percentage.}
+     }
+   }
+}
 }
 \examples{
 wb <- createWorkbook()
@@ -97,6 +121,8 @@ addWorksheet(wb, "endsWith")
 addWorksheet(wb, "colourScale", zoom = 30)
 addWorksheet(wb, "databar")
 addWorksheet(wb, "between")
+addWorksheet(wb, "topN")
+addWorksheet(wb, "bottomN")
 addWorksheet(wb, "logical operators")
 
 negStyle <- createStyle(fontColour = "#9C0006", bgFill = "#FFC7CE")
@@ -213,6 +239,24 @@ conditionalFormatting(wb, "databar", cols = 1, rows = 1:11, type = "databar") ##
 # Highlight cells in interval [-2, 2]
 writeData(wb, "between", -5:5)
 conditionalFormatting(wb, "between", cols = 1, rows = 1:11, type = "between", rule = c(-2, 2))
+
+## Top N 
+writeData(wb, "topN", data.frame(x = 1:10, y = rnorm(10)))
+# Highlight top 5 values in column x
+conditionalFormatting(wb, "topN", cols = 1, rows = 2:11, 
+ style = posStyle, type = "topN", rank = 5)#'
+# Highlight top 20 percentage in column y
+conditionalFormatting(wb, "topN", cols = 2, rows = 2:11, 
+ style = posStyle, type = "topN", rank = 20, percent = TRUE)
+
+## Bottom N 
+writeData(wb, "bottomN", data.frame(x = 1:10, y = rnorm(10)))
+# Highlight bottom 5 values in column x
+conditionalFormatting(wb, "bottomN", cols = 1, rows = 2:11, 
+ style = negStyle, type = "topN", rank = 5)
+# Highlight bottom 20 percentage in column y
+conditionalFormatting(wb, "bottomN", cols = 2, rows = 2:11, 
+ style = negStyle, type = "topN", rank = 20, percent = TRUE)
 
 ## Logical Operators
 # You can use Excels logical Opertors

--- a/man/conditionalFormatting.Rd
+++ b/man/conditionalFormatting.Rd
@@ -235,7 +235,7 @@ setRowHeights(wb, "colourScale", rows = 1:nrow(df), heights = 7.5)
 writeData(wb, "databar", -5:5)
 conditionalFormatting(wb, "databar", cols = 1, rows = 1:11, type = "databar") ## Default colours
 
-## Betweem
+## Between
 # Highlight cells in interval [-2, 2]
 writeData(wb, "between", -5:5)
 conditionalFormatting(wb, "between", cols = 1, rows = 1:11, type = "between", rule = c(-2, 2))
@@ -259,7 +259,7 @@ conditionalFormatting(wb, "bottomN", cols = 2, rows = 2:11,
  style = negStyle, type = "topN", rank = 20, percent = TRUE)
 
 ## Logical Operators
-# You can use Excels logical Opertors
+# You can use Excels logical Operators
 writeData(wb, "logical operators", 1:10)
 conditionalFormatting(wb, "logical operators",
   cols = 1, rows = 1:10,


### PR DESCRIPTION
Closes Issue #146 

- Adds 'topN' and 'bottomN' options to the `type` argument in `conditionalFormatting` function along with supporting arguments like `rank` and `percent` to let user determine of they need top/bottom N values or top/bottom N percentage.
- Updated documentation to include these options and corrected 2 spelling mistakes in existing documentation.