### PR TITLE
fix convertToDate() for dates before 1900-03-01

### DIFF
--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -2574,8 +2574,10 @@ worksheetOrder <- function(wb) {
 convertToDate <- function(x, origin = "1900-01-01", ...) {
   x <- as.numeric(x)
   notNa <- !is.na(x)
+  earlyDate <- x < 60
   if (origin == "1900-01-01") {
     x[notNa] <- x[notNa] - 2
+    x[earlyDate & notNa] <- x[earlyDate & notNa] + 1
   }
   
   return(as.Date(x, origin = origin, ...))

--- a/tests/testthat/test-date_time_conversion.R
+++ b/tests/testthat/test-date_time_conversion.R
@@ -10,6 +10,11 @@ test_that("convert to date", {
   n <- as.integer(dates) + origin
 
   expect_equal(convertToDate(n), dates)
+
+  earlyDate <- as.Date("1900-01-03")
+  serialDate <- 3
+  expect_equal(convertToDate(serialDate), earlyDate)
+
 })
 
 


### PR DESCRIPTION
related to issue #80. This fixes reading only. Writing is not fixed.

This is not an issue for most commonly used dates, but it is a problem for someone testing the function against what should be a known good date such as "1900-01-01" => 1