### PR TITLE
getChildlessNode >> getChildlessNode_ss; adds testing

### DIFF
--- a/R/helperFunctions.R
+++ b/R/helperFunctions.R
@@ -462,7 +462,7 @@ getAttrsFont <- function(xml, tag) {
 }
 
 getAttrs <- function(xml, tag) {
-  x <- lapply(xml, getChildlessNode, tag = tag)
+  x <- lapply(xml, getChildlessNode_ss, tag = tag)
   x[sapply(x, length) == 0] <- ""
   a <- lapply(x, function(x) regmatches(x, regexpr('[a-zA-Z]+=".*?"', x)))
 

--- a/tests/testthat/test-getBaseFont.R
+++ b/tests/testthat/test-getBaseFont.R
@@ -1,0 +1,22 @@
+test_that("getBaseFont works", {
+  wb <- createWorkbook()
+  expect_equal(
+    getBaseFont(wb),
+    list(
+      size = list(val = "11"),
+      # should this be "#000000"?
+      colour = list(rgb = "FF000000"),
+      name = list(val = "Calibri")
+    )
+  )
+  
+  modifyBaseFont(wb, fontSize = 9, fontName = "Arial", fontColour = "red")
+  expect_equal(
+    getBaseFont(wb), 
+    list(
+      size = list(val = "9"),
+      colour = list(rgb = "FFFF0000"),
+      name = list(val = "Arial")
+    )
+  )
+})


### PR DESCRIPTION
Should resolve #162 

Testing didn't seem to affect anything else.  However, the default value when the colour cannot be retrieved is `"#000000"`, rather than `"FF000000"` as a fresh workbook uses as a default.