### PR TITLE
Add detail to the error when failing to import dates

### DIFF
--- a/src/write_file.cpp
+++ b/src/write_file.cpp
@@ -228,7 +228,12 @@ SEXP buildMatrixMixed(CharacterVector v,
         }else{
           // dt_str = as<std::string>(m(ri,i));
           dt_str = m(ri,i);
-          datetmp[ri] = Rcpp::Date(atoi(dt_str.substr(5,2).c_str()), atoi(dt_str.substr(8,2).c_str()), atoi(dt_str.substr(0,4).c_str()) );
+          try{
+            datetmp[ri] = Rcpp::Date(atoi(dt_str.substr(5,2).c_str()), atoi(dt_str.substr(8,2).c_str()), atoi(dt_str.substr(0,4).c_str()) );
+          }catch(...) {
+            std::cerr << "Error reading date:\n" << dt_str << "\nrow: " << ri+1 << "\ncol: " << i+1 << "\n";
+            throw;
+          }
           //datetmp[ri] = Date(atoi(m(ri,i)) - originAdj);
           //datetmp[ri] = Date(as<std::string>(m(ri,i)));
         }

--- a/src/write_file.cpp
+++ b/src/write_file.cpp
@@ -231,7 +231,7 @@ SEXP buildMatrixMixed(CharacterVector v,
           try{
             datetmp[ri] = Rcpp::Date(atoi(dt_str.substr(5,2).c_str()), atoi(dt_str.substr(8,2).c_str()), atoi(dt_str.substr(0,4).c_str()) );
           }catch(...) {
-            std::cerr << "Error reading date:\n" << dt_str << "\nrow: " << ri+1 << "\ncol: " << i+1 << "\n";
+            Rcpp::Rcerr << "Error reading date:\n" << dt_str << "\nrow: " << ri+1 << "\ncol: " << i+1 << "\n";
             throw;
           }
           //datetmp[ri] = Date(atoi(m(ri,i)) - originAdj);


### PR DESCRIPTION
Fixes a bug where importing a sheet with a date colum that also
contained invalid dates would fail with a c++ exception and no other
info.
Adds detail to the error display when failing. Shows the user the text
that failed to import correctly along with the row and column numbers.
Rethrows the exception so that the process still fails to avoid
unanticipated behavior if someone doesn't look at the error messages.
Fixes #172