### PR TITLE
check for POSIXlt and convert it to POSIXct. closes #158

### DIFF
--- a/R/workbook_write_data.R
+++ b/R/workbook_write_data.R
@@ -18,6 +18,11 @@ Workbook$methods(writeData = function(
   df_nms <- names(df)
 
   allColClasses <- unlist(colClasses)
+  
+  isPOSIXlt <- function(data) sapply(lapply(data, class), FUN = function(x) any(x == "POSIXlt"))
+  
+  df[isPOSIXlt(df)] <- lapply(df[isPOSIXlt(df)], as.POSIXct)
+  
   df <- as.list(df)
 
   ######################################################################

--- a/R/workbook_write_data.R
+++ b/R/workbook_write_data.R
@@ -20,8 +20,13 @@ Workbook$methods(writeData = function(
   allColClasses <- unlist(colClasses)
   
   isPOSIXlt <- function(data) sapply(lapply(data, class), FUN = function(x) any(x == "POSIXlt"))
+  to_convert <- isPOSIXlt(df)
   
-  df[isPOSIXlt(df)] <- lapply(df[isPOSIXlt(df)], as.POSIXct)
+  if (any(to_convert)) {
+    message("Found POSIXlt. Converting to POSIXct")
+    df[to_convert] <- lapply(df[to_convert], as.POSIXct)  
+  }
+  
   
   df <- as.list(df)
 


### PR DESCRIPTION
# the issue
Dates written as `POSIXlt` are lists and there is no `is.nan` for lists. Still we use `is.nan` on every column of a `data.frame`. 

I am not sure if `openxlsx` should do anything or leave that to the user, still it might be beneficial from a user experience point of view.

# the fix
If we want to pick up the ball,  there are several ways to approach this issue (for example writing a new `is.nan`, rewriting or dropping the faulty code segment or adding more checks in the list). I propose to simply convert any `POSIXlt` to `POSIXct` and print a warning to the user.


We are bitten in this line:
https://github.com/ycphs/openxlsx/blob/8b9d5af3b528ba53c940a6194b2875553f4ebef0/R/workbook_write_data.R#L27-L36

# the mwe
```r 
library(openxlsx)

# create initial data
income <- read.xlsx("https://github.com/ycphs/openxlsx/files/6217835/test.xlsx")
income$X1 <- NULL

# create POSIXlt/ct
income$Buchungsdatum <- as.POSIXlt(convertToDate(income$Buchungsdatum))
income$Valutadatum   <- as.POSIXlt(convertToDate(income$Valutadatum))
income$week          <- as.POSIXct(convertToDate(income$week))
income$month         <- as.POSIXct(convertToDate(income$month))
income$year          <- as.POSIXct(convertToDate(income$year))

# isPOSIXlt <- function(data) sapply(lapply(data, class), FUN = function(x) any(x == "POSIXlt"))
# 
# income[isPOSIXlt(income)] <- lapply(income[isPOSIXlt(income)], as.POSIXct)


head(income)

# test function of openxlsx code i suspect to be causing the issue
test <- function(df) {
  
  nCols <- ncol(df)
  
  nans <- unlist(lapply(1:nCols, function(i) { 
    tmp <- df[[i]] 
    if (!"character" %in% class(tmp) & !"list" %in% class(tmp)) { 
      v <- which(is.nan(tmp) | is.infinite(tmp)) 
      if (length(v) == 0) { 
        return(v) 
      } 
      return(as.integer(nCols * (v - 1) + i)) ## row position 
    } 
  }))
  
  message("done")
  
}

# boom
try(test(income))

if (!dir.exists("/tmp/001_Export/")) dir.create("/tmp/001_Export")
setwd("/tmp/001_Export")

excel_overview_file              <- createWorkbook()
excel_overview_income            <- addWorksheet(wb = excel_overview_file, sheetName = "Income")
excel_overview_orig              <- addWorksheet(wb = excel_overview_file, sheetName = "Cumulated costs")
excel_overview_fixed             <- addWorksheet(wb = excel_overview_file, sheetName = "Fixed costs")
excel_overview_variable          <- addWorksheet(wb = excel_overview_file, sheetName = "Variable costs")
excel_overview_fixcats_monthly   <- addWorksheet(wb = excel_overview_file, sheetName = "Fixcats_Monthly")
excel_overview_varcats_monthly   <- addWorksheet(wb = excel_overview_file, sheetName = "Varcats_Monthly")
excel_overview_fixcats_yearly    <- addWorksheet(wb = excel_overview_file, sheetName = "Fixcats_Yearly")
excel_overview_varcats_yearly    <- addWorksheet(wb = excel_overview_file, sheetName = "Varcats_Yearly")
excel_overview_finanz            <- addWorksheet(wb = excel_overview_file, sheetName = "Steuerausgleich")
#excel_origin <- addWorksheet(wb = excel_file, sheetName = "Original data")
excel_overview_title <- ("001a_Finanzdaten_kumuliert.xlsx")

writeDataTable(wb = excel_overview_file, x = income, sheet = excel_overview_income, 
               withFilter = TRUE, keepNA = FALSE, na.string = NULL)

saveWorkbook(overwrite = TRUE, excel_overview_file, excel_overview_title)

```
