### PR TITLE
avoid replaceIllegalCharacters for hyperlinks. fixes #200

### DIFF
--- a/R/workbook_write_data.R
+++ b/R/workbook_write_data.R
@@ -104,6 +104,12 @@ Workbook$methods(writeData = function(
     }
   }
 
+  if ("hyperlink" %in% allColClasses) {
+    for (i in which(sapply(colClasses, function(x) "hyperlink" %in% x))) {
+      class(df[[i]]) <- "hyperlink"
+    }
+  }
+
   if (any(c("formula", "array_formula") %in% allColClasses)) {
     
     frm <- "formula"
@@ -117,12 +123,6 @@ Workbook$methods(writeData = function(
     for (i in which(sapply(colClasses, function(x) frm %in% x))) {
       df[[i]] <- replaceIllegalCharacters(as.character(df[[i]]))
       class(df[[i]]) <- cls
-    }
-  }
-
-  if ("hyperlink" %in% allColClasses) {
-    for (i in which(sapply(colClasses, function(x) "hyperlink" %in% x))) {
-      class(df[[i]]) <- "hyperlink"
     }
   }
 


### PR DESCRIPTION
Formulas containing hyperlinks should not be treated with `replaceIllegalCharacters()`. This fixes the issue, but I'm currently a bit to sleepy to understand what is really going on. Might have broken this, when adding array formulas.

The unit test writes the excel, extracts it, imports the xls file as text and compares it with the expected values.