### PR TITLE
[WIP] use all available fonts (do not merge)

### DIFF
--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -1088,13 +1088,13 @@ Workbook$methods(
     )
 
     ## reset styles - maintain any changes to base font
-    baseFont <- styles$fonts[[1]]
-    styles <<-
-      genBaseStyleSheet(styles$dxfs,
-        tableStyles = styles$tableStyles,
-        extLst = styles$extLst
-      )
-    styles$fonts[[1]] <<- baseFont
+    #baseFont <- styles$fonts[[1]]
+    #styles <<-
+    #  genBaseStyleSheet(styles$dxfs,
+    #    tableStyles = styles$tableStyles,
+    #    extLst = styles$extLst
+    #  )
+    #styles$fonts[[1]] <<- baseFont
 
 
     return(file.path(tmpDir, tmpFile))
@@ -3989,9 +3989,10 @@ Workbook$methods(
           c(getNodes(xml, tagIn = "<font>"), "")
         }))
     } else {
-      fonts <- getNodes(xml = stylesTxt, tagIn = "<font>")
+      fonts <- getNodes(xml = stylesTxt, tagIn = "<fonts")
+      fonts <- getNodes(paste0(fonts, ">"), "<font>")
     }
-    styles$fonts[[1]] <<- fonts[[1]]
+    styles$fonts <<- fonts
     fonts <- buildFontList(fonts)
 
 


### PR DESCRIPTION
This is related to #228 . For whatever kind of reason not all fonts are loaded nor written. (And I cannot say, that it is not my fault :smile: .)

This pull requests is currently set up to demonstrate the issue. Load the file attached to this PR with this branch:

```R
> wb$styles$fonts
[1] "<font><sz val=\"10\"/><name val=\"Arial\"/><family val=\"2\"/></font>"                                                     
[2] "<font><sz val=\"10\"/><name val=\"Arial\"/><family val=\"0\"/></font>"                                                     
[3] "<font><sz val=\"10\"/><name val=\"Arial\"/><family val=\"0\"/></font>"                                                     
[4] "<font><sz val=\"10\"/><name val=\"Arial\"/><family val=\"0\"/></font>"                                                     
[5] "<font><b val=\"true\"/><sz val=\"10\"/><name val=\"Arial\"/><family val=\"2\"/></font>"                                    
[6] "<font><u val=\"single\"/><sz val=\"10\"/><name val=\"Arial\"/><family val=\"2\"/></font>"                                  
[7] "<font><i val=\"true\"/><sz val=\"10\"/><name val=\"Arial\"/><family val=\"2\"/></font>"                                    
[8] "<font><b val=\"true\"/><i val=\"true\"/><u val=\"single\"/><sz val=\"10\"/><name val=\"Arial\"/><family val=\"2\"/></font>"
```

After saving the workbook: magically new fonts appear.

```R
> wb$styles$fonts
 [1] "<font><sz val=\"10\"/><name val=\"Arial\"/><family val=\"2\"/></font>"                                                     
 [2] "<font><sz val=\"10\"/><name val=\"Arial\"/><family val=\"0\"/></font>"                                                     
 [3] "<font><sz val=\"10\"/><name val=\"Arial\"/><family val=\"0\"/></font>"                                                     
 [4] "<font><sz val=\"10\"/><name val=\"Arial\"/><family val=\"0\"/></font>"                                                     
 [5] "<font><b val=\"true\"/><sz val=\"10\"/><name val=\"Arial\"/><family val=\"2\"/></font>"                                    
 [6] "<font><u val=\"single\"/><sz val=\"10\"/><name val=\"Arial\"/><family val=\"2\"/></font>"                                  
 [7] "<font><i val=\"true\"/><sz val=\"10\"/><name val=\"Arial\"/><family val=\"2\"/></font>"                                    
 [8] "<font><b val=\"true\"/><i val=\"true\"/><u val=\"single\"/><sz val=\"10\"/><name val=\"Arial\"/><family val=\"2\"/></font>"
 [9] "<font><sz val=\"10\"/><color rgb=\"#000000\"/><name val=\"Arial\"/><family val = \"2\"/><b/></font>"                       
[10] "<font><sz val=\"10\"/><color rgb=\"#000000\"/><name val=\"Arial\"/><family val = \"2\"/><u val=\"single\"/></font>"        
[11] "<font><sz val=\"10\"/><color rgb=\"#000000\"/><name val=\"Arial\"/><family val = \"2\"/><i/></font>"                       
[12] "<font><sz val=\"10\"/><color rgb=\"#000000\"/><name val=\"Arial\"/><family val = \"2\"/><b/><i/><u val=\"single\"/></font>"
```

Without this branch:

```R
> wb$styles$fonts
[1] "<font><sz val=\"10\"/><name val=\"Arial\"/><family val=\"2\"/></font>"
```

Something is messed up. I had to comment the lines in saveWorkbook, because they are erasing every available font. (Simply reset them to this default font.) Someone should look into this, I'm heavily annoyed by these S4 classes, so it's at the very end of my ToDo-List, but it has the potential to affect many users.

[font_test.xlsx](https://github.com/ycphs/openxlsx/files/6887675/font_test.xlsx)