### PR TITLE
[WIP] Fixes a regression in 4.2.4 and restores loading <foo/>. closes # 207

### DIFF
--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -4061,7 +4061,7 @@ Workbook$methods(
             }
 
             flags <-
-              c("bold", "italic", "underline") %in% names(thisFont)
+              c("bold", "italic", "underline", "strikeout") %in% names(thisFont)
             if (any(flags)) {
               style$fontDecoration <- NULL
               if (flags[[1]]) {
@@ -4077,6 +4077,11 @@ Workbook$methods(
               if (flags[[3]]) {
                 style$fontDecoration <-
                   append(style$fontDecoration, "UNDERLINE")
+              }
+
+              if (flags[[4]]) {
+                style$fontDecoration <-
+                  append(style$fontDecoration, "STRIKEOUT")
               }
             }
           }

--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -1640,9 +1640,9 @@ Workbook$methods(
   getBaseFont = function() {
     baseFont <- styles$fonts[[1]]
 
-    sz <- getAttrs(baseFont, "<sz ")
-    colour <- getAttrs(baseFont, "<color ")
-    name <- getAttrs(baseFont, "<name ")
+    sz <- getAttrs(baseFont, "sz")
+    colour <- getAttrs(baseFont, "color")
+    name <- getAttrs(baseFont, "name")
 
     if (length(sz[[1]]) == 0) {
       sz <- list("val" = "10")

--- a/R/helperFunctions.R
+++ b/R/helperFunctions.R
@@ -465,11 +465,11 @@ getAttrs <- function(xml, tag) {
 
 
 buildFontList <- function(fonts) {
-  sz <- getAttrs(fonts, "<sz ")
-  colour <- getAttrsFont(fonts, "<color ")
-  name <- getAttrs(fonts, tag = "<name ")
-  family <- getAttrs(fonts, "<family ")
-  scheme <- getAttrs(fonts, "<scheme ")
+  sz <- getAttrs(fonts, "sz")
+  colour <- getAttrsFont(fonts, "color")
+  name <- getAttrs(fonts, tag = "name")
+  family <- getAttrs(fonts, "family")
+  scheme <- getAttrs(fonts, "scheme")
   
   italic <- lapply(fonts, getChildlessNode, tag = "i")
   bold <- lapply(fonts, getChildlessNode, tag = "b")

--- a/R/helperFunctions.R
+++ b/R/helperFunctions.R
@@ -473,8 +473,9 @@ buildFontList <- function(fonts) {
   
   italic <- lapply(fonts, getChildlessNode, tag = "i")
   bold <- lapply(fonts, getChildlessNode, tag = "b")
-  underline <- lapply(fonts, getChildlessNode, tag = "u")
-  
+  underline <- lapply(fonts, getChildlessNode, tag = "u")  
+  strikeout <- lapply(fonts, getChildlessNode, tag = "strike")
+
   ## Build font objects
   ft <- replicate(list(), n = length(fonts))
   for (i in seq_along(fonts)) {
@@ -518,6 +519,11 @@ buildFontList <- function(fonts) {
     if (length(underline[[i]]) > 0) {
       f <- c(f, "underline")
       nms <- c(nms, "underline")
+    }
+
+    if (length(unlist(strikeout[i])) > 0) {
+      f <- c(f, strikeout[i])
+      nms <- c(nms, "strikeout")
     }
     
     f <- lapply(seq_along(f), function(i) unlist(f[i]))

--- a/src/load_workbook.cpp
+++ b/src/load_workbook.cpp
@@ -926,7 +926,7 @@ CharacterVector getChildlessNode(std::string xml, std::string tag) {
     // check if we have either <foo ...>, <foo/>, or <foo>. We have to avoid
     // <foos...>
     while (
-        res.substr(begTag.length(),1).compare(" ") != 0 && // <foo ...>
+        res.substr(begTag.length(),1).compare(" ") != 0 &&   // <foo ...>
           res.substr(begTag.length(),1).compare("/") != 0 && // <foo/>
           res.substr(begTag.length(),1).compare(">") != 0    // <foo>
     ) {
@@ -941,7 +941,6 @@ CharacterVector getChildlessNode(std::string xml, std::string tag) {
 
       if(begPos == std::string::npos || endPos == std::string::npos) break;
       res = xml.substr(begPos, (endPos - begPos) + endTag.length());
-      begPos = begPos + endTag.length();
 
       ++itr;
     }

--- a/src/load_workbook.cpp
+++ b/src/load_workbook.cpp
@@ -900,7 +900,7 @@ CharacterVector getChildlessNode(std::string xml, std::string tag) {
   if(xml.length() == 0)
     return wrap(NA_STRING);
   
-  size_t begPos = 0, endPos = 0;
+  size_t begPos = 0, endPos = 0, goit = 0;
   
   std::vector<std::string> r;
   std::string res = "";
@@ -908,6 +908,15 @@ CharacterVector getChildlessNode(std::string xml, std::string tag) {
   // check "<tag "
   std::string begTag = "<" + tag + " ";
   std::string endTag = ">";
+  std::string begendTag = "<" + tag + "/>";
+
+  goit = xml.find(begendTag, begPos);
+  if (goit != std::string::npos) {
+    r.push_back(begendTag);
+
+    CharacterVector out = wrap(r);  
+    return markUTF8(out);
+  }
   
   // initial check, which kind of tags to expect
   begPos = xml.find(begTag, begPos);

--- a/src/load_workbook.cpp
+++ b/src/load_workbook.cpp
@@ -904,10 +904,8 @@ CharacterVector getChildlessNode(std::string xml, std::string tag) {
   
   std::vector<std::string> r;
   std::string res = "";
-  
-  // check "<tag "
-  std::string begTag = "<" + tag + " ";
-  std::string endTag = ">";
+
+  // check "<tag/>"
   std::string begendTag = "<" + tag + "/>";
 
   goit = xml.find(begendTag, begPos);
@@ -917,6 +915,10 @@ CharacterVector getChildlessNode(std::string xml, std::string tag) {
     CharacterVector out = wrap(r);  
     return markUTF8(out);
   }
+  
+  // check "<tag "
+  std::string begTag = "<" + tag + " ";
+  std::string endTag = ">";
   
   // initial check, which kind of tags to expect
   begPos = xml.find(begTag, begPos);

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -967,12 +967,12 @@ test_that("read nodes", {
 
   # read single node
   test <- "<xf numFmtId=\"0\" fontId=\"4\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\" applyAlignment=\"1\"><alignment horizontal=\"center\"/></xf>"
-  that <- getChildlessNode(test, "xf")
+  that <- openxlsx:::getChildlessNode(test, "xf")
   expect_equal(test, that)
 
   # real life example <foo/> and <foo>...</foo> mixed
   cellXfs <- "<cellXfs count=\"8\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/><xf numFmtId=\"0\" fontId=\"1\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/><xf numFmtId=\"0\" fontId=\"3\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/><xf numFmtId=\"0\" fontId=\"5\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/><xf numFmtId=\"0\" fontId=\"6\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/><xf numFmtId=\"0\" fontId=\"2\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/><xf numFmtId=\"0\" fontId=\"7\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/><xf numFmtId=\"0\" fontId=\"4\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\" applyAlignment=\"1\"><alignment horizontal=\"center\"/></xf><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/></cellXfs>"
-  that <- getChildlessNode(cellXfs, "xf")
+  that <- openxlsx:::getChildlessNode(cellXfs, "xf")
   test <- c("<xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/>", 
             "<xf numFmtId=\"0\" fontId=\"1\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/>", 
             "<xf numFmtId=\"0\" fontId=\"3\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/>", 
@@ -987,7 +987,7 @@ test_that("read nodes", {
 
   # test <foos/>
   test <- "<xfs bla/>"
-  that <- getChildlessNode(test, "xf")
+  that <- openxlsx:::getChildlessNode(test, "xf")
   expect_equal(character(0), that)
 
   # test <foo/>
@@ -1001,9 +1001,14 @@ test_that("read nodes", {
 
   # test <foo>...</foo>
   test <- "<b>a</b><b/>"
-  that <- getChildlessNode(test, "b")
+  that <- openxlsx:::getChildlessNode(test, "b")
+  test <- c("<b>a</b>", "<b/>")
   expect_equal(test, that)
 
+  # test <foos><foo/></foos>
+  test <- "<xfs><xf/></xfs>"
+  that <- openxlsx:::getChildlessNode(test, "xf")
+  test <- "<xf/>"
+  expect_equal(test, that)
+  
 })
-
-

--- a/tests/testthat/test-loading_workbook.R
+++ b/tests/testthat/test-loading_workbook.R
@@ -961,3 +961,49 @@ test_that("Read and save file with inlineStr", {
   expect_true(all.equal(wb_df, wb_df_re, compare.attributes = FALSE))
   
 })
+
+# tests for getChildlessNode returns the content of every node, single node or not. the name has only historical meaning
+test_that("read nodes", {
+
+  # read single node
+  test <- "<xf numFmtId=\"0\" fontId=\"4\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\" applyAlignment=\"1\"><alignment horizontal=\"center\"/></xf>"
+  that <- getChildlessNode(test, "xf")
+  expect_equal(test, that)
+
+  # real life example <foo/> and <foo>...</foo> mixed
+  cellXfs <- "<cellXfs count=\"8\"><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/><xf numFmtId=\"0\" fontId=\"1\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/><xf numFmtId=\"0\" fontId=\"3\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/><xf numFmtId=\"0\" fontId=\"5\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/><xf numFmtId=\"0\" fontId=\"6\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/><xf numFmtId=\"0\" fontId=\"2\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/><xf numFmtId=\"0\" fontId=\"7\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/><xf numFmtId=\"0\" fontId=\"4\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\" applyAlignment=\"1\"><alignment horizontal=\"center\"/></xf><xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/></cellXfs>"
+  that <- getChildlessNode(cellXfs, "xf")
+  test <- c("<xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/>", 
+            "<xf numFmtId=\"0\" fontId=\"1\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/>", 
+            "<xf numFmtId=\"0\" fontId=\"3\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/>", 
+            "<xf numFmtId=\"0\" fontId=\"5\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/>", 
+            "<xf numFmtId=\"0\" fontId=\"6\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/>", 
+            "<xf numFmtId=\"0\" fontId=\"2\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/>", 
+            "<xf numFmtId=\"0\" fontId=\"7\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\"/>", 
+            "<xf numFmtId=\"0\" fontId=\"4\" fillId=\"0\" borderId=\"0\" xfId=\"0\" applyFont=\"1\" applyAlignment=\"1\"><alignment horizontal=\"center\"/></xf>", 
+            "<xf numFmtId=\"0\" fontId=\"0\" fillId=\"0\" borderId=\"0\" xfId=\"0\"/>"
+  )
+  expect_equal(test, that)
+
+  # test <foos/>
+  test <- "<xfs bla/>"
+  that <- getChildlessNode(test, "xf")
+  expect_equal(character(0), that)
+
+  # test <foo/>
+  test <- "<b/><b/>"
+  that <- openxlsx:::getChildlessNode(test, "b")
+  test <- c(
+    "<b/>",
+    "<b/>"
+  )
+  expect_equal(test, that)
+
+  # test <foo>...</foo>
+  test <- "<b>a</b><b/>"
+  that <- getChildlessNode(test, "b")
+  expect_equal(test, that)
+
+})
+
+


### PR DESCRIPTION
Fixes reading `<b/>` tag in font. Previously only `<b val="true"/>` was imported, but `<b/>` is valid too. I assume this was caused by my last attempt to fix this function. Needs some unittests and maybe someone should check if this actually fixes the error *and* what precisely `getChildlessNode()` should do.

A remaining question is: are multiple values supported e.g. should these two be detected and returned: `openxlsx:::getChildlessNode("<b foo=\"1\"/><b foo=\"1\"/><b/>", "b")`? The current implementation works like this for cases unlike `<foo/>`. With `<foo/>` only a a single string is returned. For `<fonts>` this shouldn't matter as all `<font>` nodes are separated before `getChildlessNode()` is called.

Ultimately this _needs_ testing.

This is related to #207 and ~~maybe~~ #228 ~~(but I didn't test this)~~.

Some lines to test, should be converted to a test:
```R
# tests, 1 indicates a result is returned
openxlsx:::getChildlessNode("<b/>", "b") # 1
openxlsx:::getChildlessNode("<b foo=\"1\"/><b/>", "b") # 1
openxlsx:::getChildlessNode("<b>foo</b>", "b") # 0
openxlsx:::getChildlessNode("<ba/>", "b") # 0
openxlsx:::getChildlessNode("<ba foo=\"1\"/>", "b") #0
```

Note to self:
```R
# Most likely something for another issue. File is from #232 
wb <- loadWorkbook("~/font_test.xlsx")
saveWorkbook(wb, "/tmp/test.xlsx", TRUE)

# This produces a broken file
wb2 <- loadWorkbook("/tmp/test.xlsx")
saveWorkbook(wb2, "/tmp/test2.xlsx", overwrite = TRUE)
```
