### PR TITLE
Accounting underline option

### DIFF
--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -1761,6 +1761,14 @@ Workbook$methods(
       fontNode <- stri_join(fontNode, '<u val="double"/>')
     }
 
+    if ("ACCOUNTING" %in% style$fontDecoration) {
+      fontNode <- stri_join(fontNode, '<u val="singleAccounting"/>')
+    }
+
+    if ("ACCOUNTING2" %in% style$fontDecoration) {
+      fontNode <- stri_join(fontNode, '<u val="doubleAccounting"/>')
+    }
+
     if ("STRIKEOUT" %in% style$fontDecoration) {
       fontNode <- stri_join(fontNode, "<strike/>")
     }

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -707,6 +707,8 @@ convertFromExcelRef <- function(col) {
 #'    \item{\bold{italic}}{ Italicise cell contents}
 #'    \item{\bold{underline}}{ Underline cell contents}
 #'    \item{\bold{underline2}}{ Double underline cell contents}
+#'    \item{\bold{accounting}}{ Single accounting underline cell contents}
+#'    \item{\bold{accounting2}}{ Double accounting underline cell contents}
 #'   }
 #'
 #' @param wrapText Logical. If \code{TRUE} cell contents will wrap to fit in column.
@@ -828,7 +830,7 @@ createStyle <- function(fontName = NULL,
 
   textDecoration <- tolower(textDecoration)
   if (!is.null(textDecoration)) {
-    if (!all(textDecoration %in% c("bold", "strikeout", "italic", "underline", "underline2", ""))) {
+    if (!all(textDecoration %in% c("bold", "strikeout", "italic", "underline", "underline2", "accounting", "accounting2", ""))) {
       stop("Invalid textDecoration!")
     }
   }

--- a/man/createStyle.Rd
+++ b/man/createStyle.Rd
@@ -115,6 +115,8 @@ Vertical alignment of cell contents
    \item{\bold{italic}}{ Italicise cell contents}
    \item{\bold{underline}}{ Underline cell contents}
    \item{\bold{underline2}}{ Double underline cell contents}
+   \item{\bold{accounting}}{ Single accounting underline cell contents}
+   \item{\bold{accounting2}}{ Double accounting underline cell contents}
   }}
 
 \item{wrapText}{Logical. If \code{TRUE} cell contents will wrap to fit in column.}


### PR DESCRIPTION
Fixes Issue [#256](https://github.com/ycphs/openxlsx/issues/256)

add single accounting and double accounting underline option to textDecoration parameter in createStyle