### PR TITLE
`writeData()` force evaluation of `x` before options are set

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 Language: en-US
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Collate: 
     'CommentClass.R'
     'HyperlinkClass.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * add option to save as read only recommended ([#201](https://github.com/ychps/openxlsx/issues/201))
 * fixed writing hyperlink formulas ([#200](https://github.com/ychps/openxlsx/issues/200))
 * `write.xlsx()` now throws an error if it doesn't have write permissions ([#190](https://github.com/ycphs/openxlsx/issues/190))
+* `write.xlsx()` now again uses the default of `overwrite = TRUE` for saving files ([#249](https://github.com/ycphs/openxlsx/issues/249))
 * `Workbook$show()` no longer fails when called in a 0 sheet workbook([#240](https://github.com/ychps/openxlsx/issues/240))
 * `read.xlsx()` again accepts `.xlsm` files ([#205](https://github.com/ychps/openxlsx/issues/205),
 [#209](https://github.com/ychps/openxlsx/issues/209))

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,12 +9,11 @@
 * add option to save as read only recommended ([#201](https://github.com/ychps/openxlsx/issues/201))
 * fixed writing hyperlink formulas ([#200](https://github.com/ychps/openxlsx/issues/200))
 * `write.xlsx()` now throws an error if it doesn't have write permissions ([#190](https://github.com/ycphs/openxlsx/issues/190))
-* `write.xlsx()` now again uses the default of `overwrite = TRUE` for saving files ([#249](https://github.com/ycphs/openxlsx/issues/249))
 * `Workbook$show()` no longer fails when called in a 0 sheet workbook([#240](https://github.com/ychps/openxlsx/issues/240))
 * `read.xlsx()` again accepts `.xlsm` files ([#205](https://github.com/ychps/openxlsx/issues/205),
 [#209](https://github.com/ychps/openxlsx/issues/209))
 * `makeHyperlinkString()` does no longer require a sheet argument ([#57](https://github.com/ychps/openxlsx/issues/57), [#58](https://github.com/ychps/openxlsx/issues/58))
-
+* `writeData()` calls `force(x)` to evaluate the object before options are set ([#264](https://github.com/ycphs/openxlsx/issues/264)) 
 
 # openxlsx 4.2.4
 

--- a/R/writeData.R
+++ b/R/writeData.R
@@ -179,6 +179,8 @@ writeData <- function(
   row.names
 ) {
 
+  x <- force(x)
+  
   op <- get_set_options()
   on.exit(options(op), add = TRUE)
   

--- a/tests/testthat/test-writeData.R
+++ b/tests/testthat/test-writeData.R
@@ -1,0 +1,37 @@
+test_that("writeData() forces evaluation of x (#264)", {
+  wbfile <- temp_xlsx()
+  op <- options(stringsAsFactors = FALSE)
+  
+  x <- format(123.4)
+  df <- data.frame(d = format(123.4))
+  df2 <- data.frame(e = x)
+  
+  wb <- createWorkbook()
+  addWorksheet(wb, "sheet")
+  writeData(wb, "sheet", startCol = 1, data.frame(a = format(123.4)))
+  writeData(wb, "sheet", startCol = 2, data.frame(b = as.character(123.4)))
+  writeData(wb, "sheet", startCol = 3, data.frame(c = "123.4"))
+  writeData(wb, "sheet", startCol = 4, df)
+  writeData(wb, "sheet", startCol = 5, df2)
+  
+  saveWorkbook(wb, wbfile)
+  out <- read.xlsx(wbfile)
+  
+  # Possibly overkill
+  
+  with(out, {
+    expect_identical(a, b)
+    expect_identical(a, c)
+    expect_identical(a, d)
+    expect_identical(a, e)
+    expect_identical(b, c)
+    expect_identical(b, d)
+    expect_identical(b, e)
+    expect_identical(c, d)
+    expect_identical(c, e)
+    expect_identical(d, e)
+  })
+  
+  options(op)
+  file.remove(wbfile)
+})


### PR DESCRIPTION
Simply using `force(x)` before options seems to do the trick.

No local test fails.

resolves #264