### PR TITLE
275 create comment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 * `makeHyperlinkString()` does no longer require a sheet argument ([#57](https://github.com/ychps/openxlsx/issues/57), [#58](https://github.com/ychps/openxlsx/issues/58))
 * improvements in how `openxlsx` creates temporary directories (see [#262](https://github.com/ychps/openxlsx/issues/262))
 * `writeData()` calls `force(x)` to evaluate the object before options are set ([#264](https://github.com/ycphs/openxlsx/issues/264))
-* `createComment()` how correctly handles `integers` in `width` and `height` ([#275](https://github.com/ycphs/openxlsx/issues/275))
+* `createComment()` now correctly handles `integers` in `width` and `height` ([#275](https://github.com/ycphs/openxlsx/issues/275))
 
 # openxlsx 4.2.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * `makeHyperlinkString()` does no longer require a sheet argument ([#57](https://github.com/ychps/openxlsx/issues/57), [#58](https://github.com/ychps/openxlsx/issues/58))
 * improvements in how `openxlsx` creates temporary directories (see [#262](https://github.com/ychps/openxlsx/issues/262))
 * `writeData()` calls `force(x)` to evaluate the object before options are set ([#264](https://github.com/ycphs/openxlsx/issues/264))
+* `createComment()` how correctly handles `integers` in `width` and `height` ([#275](https://github.com/ycphs/openxlsx/issues/275))
 
 # openxlsx 4.2.4
 

--- a/R/CommentClass.R
+++ b/R/CommentClass.R
@@ -104,19 +104,14 @@ createComment <- function(comment,
     stop("comment argument must be a character vector")
   }
 
-  if (!"numeric" %in% class(width)) {
-    stop("width argument must be a numeric vector")
-  }
-
-  if (!"numeric" %in% class(height)) {
-    stop("height argument must be a numeric vector")
-  }
 
   if (!"logical" %in% class(visible)) {
     stop("visible argument must be a logical vector")
   }
 
 
+  assert_numeric1(width)
+  assert_numeric1(height)
 
   width <- round(width)
   height <- round(height)

--- a/R/CommentClass.R
+++ b/R/CommentClass.R
@@ -96,29 +96,18 @@ createComment <- function(comment,
                           visible = TRUE,
                           width = 2,
                           height = 4) {
-  if (!"character" %in% class(author)) {
-    stop("author argument must be a character vector")
-  }
-
-  if (!"character" %in% class(comment)) {
+  
+  if (!is.character(comment)) {
     stop("comment argument must be a character vector")
   }
 
-
-  if (!"logical" %in% class(visible)) {
-    stop("visible argument must be a logical vector")
-  }
-
-
+  assert_character1(author)
   assert_numeric1(width)
   assert_numeric1(height)
+  assert_true_false1(visible)
 
   width <- round(width)
   height <- round(height)
-
-  # n <- length(comment) variable not used
-  author <- author[1]
-  visible <- visible[1]
 
   if (is.null(style)) {
     style <- createStyle(fontName = "Tahoma", fontSize = 9, fontColour = "black")
@@ -127,12 +116,8 @@ createComment <- function(comment,
   author <- replaceIllegalCharacters(author)
   comment <- replaceIllegalCharacters(comment)
 
-
   invisible(Comment$new(text = comment, author = author, style = style, visible = visible, width = width[1], height = height[1]))
 }
-
-
-
 
 
 #' @name writeComment
@@ -213,9 +198,6 @@ writeComment <- function(wb, sheet, col, row, comment, xy = NULL) {
 }
 
 
-
-
-
 #' @name removeComment
 #' @title Remove a comment from a cell
 #' @description Remove a cell comment from a worksheet
@@ -231,10 +213,7 @@ writeComment <- function(wb, sheet, col, row, comment, xy = NULL) {
 removeComment <- function(wb, sheet, cols, rows, gridExpand = TRUE) {
   sheet <- wb$validateSheet(sheet)
 
-  if (!"Workbook" %in% class(wb)) {
-    stop("First argument must be a Workbook.")
-  }
-
+  assert_class(wb, "Workbook")
   cols <- convertFromExcelRef(cols)
   rows <- as.integer(rows)
 

--- a/R/CommentClass.R
+++ b/R/CommentClass.R
@@ -1,6 +1,5 @@
 
 
-
 Comment <- setRefClass("Comment",
   fields = c(
     "text",
@@ -67,10 +66,11 @@ Comment$methods(show = function() {
 #' @description Create a cell Comment object to pass to writeComment()
 #' @param comment Comment text. Character vector.
 #' @param author Author of comment. Character vector of length 1
-#' @param style A Style object or list of style objects the same length as comment vector. See \code{\link{createStyle}}.
+#' @param style A Style object or list of style objects the same length as
+#'   comment vector. See \code{\link{createStyle}}.
 #' @param visible TRUE or FALSE. Is comment visible.
-#' @param width Textbox integer width in number of cells
-#' @param height Textbox integer height in number of cells
+#' @param width,height Width and height of textbook (in number of cells);
+#'   doubles are rounded with \code{base::round()}
 #' @export
 #' @seealso \code{\link{writeComment}}
 #' @examples

--- a/R/asserts.R
+++ b/R/asserts.R
@@ -67,7 +67,7 @@ assert_numeric1 <- function(x, scalar = FALSE) {
   ok <- is.numeric(x) & length(x) == 1L
   
   if (scalar) {
-    ok <- ok && length(x) == 1L
+    ok <- ok && nchar(x) == 1L
     msg <- paste0(msg, "single number")
   } else {
     msg <- paste0(msg, "numeric vector of length 1L")

--- a/R/asserts.R
+++ b/R/asserts.R
@@ -62,6 +62,22 @@ assert_unique <- function(x, case_sensitive = TRUE) {
   }
 }
 
+assert_numeric1 <- function(x, scalar = FALSE) {
+  msg <- paste0(substitute(x), " must be a ")
+  ok <- is.numeric(x) & length(x) == 1L
+  
+  if (scalar) {
+    ok <- ok && length(x) == 1L
+    msg <- paste0(msg, "single number")
+  } else {
+    msg <- paste0(msg, "numeric vector of length 1L")
+  }
+  
+  if (!ok) {
+    stop(msg, call. = FALSE)
+  }
+}
+
 # validates ---------------------------------------------------------------
 
 validate_StyleName <- function(x) {

--- a/man/createComment.Rd
+++ b/man/createComment.Rd
@@ -18,13 +18,13 @@ createComment(
 
 \item{author}{Author of comment. Character vector of length 1}
 
-\item{style}{A Style object or list of style objects the same length as comment vector. See \code{\link{createStyle}}.}
+\item{style}{A Style object or list of style objects the same length as
+comment vector. See \code{\link{createStyle}}.}
 
 \item{visible}{TRUE or FALSE. Is comment visible.}
 
-\item{width}{Textbox integer width in number of cells}
-
-\item{height}{Textbox integer height in number of cells}
+\item{width, height}{Width and height of textbook (in number of cells);
+doubles are rounded with \code{base::round()}}
 }
 \description{
 Create a cell Comment object to pass to writeComment()

--- a/tests/testthat/test-CommentClass.R
+++ b/tests/testthat/test-CommentClass.R
@@ -1,0 +1,18 @@
+test_that("createComment() works", {
+  # error checking
+  expect_error(createComment(width = 1), NA)
+  expect_error(createComment(width = 1L), NA)
+  expect_error(createComment(width = 1:2))
+  
+  expect_error(createComment(height = 1), NA)
+  expect_error(createComment(height = 1L), NA)
+  expect_error(createComment(height = 1:2))
+  
+  expect_error(createComment(visible = NULL))
+  expect_error(createComment(visible = c(TRUE, FALSE)))
+  
+  expect_error(createComment(author = 1))
+  expect_error(createComment(author = c("a", "a")))
+  
+  expect_s4_class(createComment("hello"), "Comment")
+})

--- a/tests/testthat/test-CommentClass.R
+++ b/tests/testthat/test-CommentClass.R
@@ -1,18 +1,18 @@
 test_that("createComment() works", {
   # error checking
-  expect_error(createComment(width = 1), NA)
-  expect_error(createComment(width = 1L), NA)
-  expect_error(createComment(width = 1:2))
+  expect_error(createComment("hi", width = 1), NA)
+  expect_error(createComment("hi", width = 1L), NA)
+  expect_error(createComment("hi", width = 1:2), "width")
   
-  expect_error(createComment(height = 1), NA)
-  expect_error(createComment(height = 1L), NA)
-  expect_error(createComment(height = 1:2))
+  expect_error(createComment("hi", height = 1), NA)
+  expect_error(createComment("hi", height = 1L), NA)
+  expect_error(createComment("hi", height = 1:2), "height")
   
-  expect_error(createComment(visible = NULL))
-  expect_error(createComment(visible = c(TRUE, FALSE)))
+  expect_error(createComment("hi", visible = NULL))
+  expect_error(createComment("hi", visible = c(TRUE, FALSE)), "visible")
   
-  expect_error(createComment(author = 1))
-  expect_error(createComment(author = c("a", "a")))
+  expect_error(createComment("hi", author = 1))
+  expect_error(createComment("hi", author = c("a", "a")), "author")
   
   expect_s4_class(createComment("hello"), "Comment")
 })


### PR DESCRIPTION
Closes #275

* Makes changes to parameter checking to allow for `integers` (as documented)
* Updates docs to be clear on how `height` and `width` should be entered
* Adds checking for single values and removes the lines that grab the first values of height, width without error/warning
* Simplifies other checks for comments
* Adds unit testing