### PR TITLE
Remove refs to missing objects from [Content_Types].xml and xl/_rels/workbook.xml.rels

### DIFF
--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -974,6 +974,10 @@ Workbook$methods(
         )
     }
 
+    for (i in seq_along(worksheets))
+      if (length(drawings[[i]])==0)
+        ct <- ct[!grepl(sprintf("drawing%s.xml", i), ct)]
+    
     ## write [Content_type]
     write_file(
       head = '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">',

--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -2140,7 +2140,13 @@ Workbook$methods(
             }
           }
 
-
+          for (i in seq_along(drawings_rels))
+            if (length(drawings_rels[[i]])==0)
+              ws_rels <- ws_rels[!grepl(sprintf("drawing%s.xml", i), ws_rels)]
+          
+          for (i in seq_along(vml_rels))
+            if (length(vml_rels[[i]])==0)
+              ws_rels <- ws_rels[!grepl(sprintf("vmlDrawing%s.vml", i), ws_rels)]
 
           write_file(
             head = '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">',


### PR DESCRIPTION
This PR to resolve issue #285--both the orig issue with broken link in [Content_Types].xml and elaboration of that issue as described in that issue's comments (broken links in xl/_rels/workbook.xml.rels )