### PR TITLE
when duplicating the style objects, assign the new sheet name

### DIFF
--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -368,7 +368,7 @@ Workbook$methods(
     styleObjects <<- c(
       styleObjects,
       Map(function(s) {
-        s$sheet <- sheetName
+        s$sheet <- clonedSheet
         s
       }, sheetStyles)
     )


### PR DESCRIPTION
I have a workbook, where style 165 is already assigned after loading. When cloning, a new (duplicated) entry for `numFmtId=165` is assigned. Looking at the code, I stumbled over this.