### PR TITLE
Do not allow `NA` as column name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 * `writeData()` calls `force(x)` to evaluate the object before options are set ([#264](https://github.com/ycphs/openxlsx/issues/264))
 * `createComment()` now correctly handles `integers` in `width` and `height` ([#275](https://github.com/ycphs/openxlsx/issues/275))
 * `setStyles()` accepts `halign="justify"` ([#305](https://github.com/ycphs/openxlsx/issues/305))
+* `data.frame`s with `NA` column names are converted to `"NA"` when saving ([#292](https://github.com/ycphs/openxlsx/issues/292), [#316](https://github.com/ycphs/openxlsx/issues/316)
 
 # openxlsx 4.2.4
 

--- a/R/writeData.R
+++ b/R/writeData.R
@@ -180,6 +180,8 @@ writeData <- function(
 ) {
 
   x <- force(x)
+  # transforms NA to "NA" for bad names
+  names(x) <- paste(names(x))
   
   op <- get_set_options()
   on.exit(options(op), add = TRUE)

--- a/tests/testthat/test-writeData.R
+++ b/tests/testthat/test-writeData.R
@@ -35,3 +35,17 @@ test_that("writeData() forces evaluation of x (#264)", {
   options(op)
   file.remove(wbfile)
 })
+
+test_that("colnames with NA are appropriately handled [292]", {
+  x <- data.frame(a = 1, b = 2)
+  colnames(x) <- c("a", NA)
+  wbfile <- temp_xlsx()
+  wb <- buildWorkbook(x)
+  wb$worksheets[[1]]$sheet_data
+  saveWorkbook(wb, wbfile)
+  
+  # what could I look for 
+  # openXL(wb)
+  # openXL(wbfile)
+  # read.xlsx(wbfile)
+})


### PR DESCRIPTION
Resolves #292 

@JanMarvin do you know how we can tell if the `NA` is converted to `"NA"` in the sheet data?

The change is in `writeData` so it should have an effect in `buildWorkbook()`.  Just couldn't get my head around what `writeData()` and `Workbook$writeData()` were doing.
