### PR TITLE
Bug #330: writeData with a date creates a new number format style, which potentially needs a unique number format ID

### DIFF
--- a/R/helperFunctions.R
+++ b/R/helperFunctions.R
@@ -132,12 +132,12 @@ classStyles <- function(wb, sheet, startRow, startCol, colNames, nRow, colClasse
   names(colClasses) <- NULL
   
   # For custom number formats, ensure unique IDs (extract the current maximum and add 1 for each new format)
-  maxnumFmtId <- max(c(sapply(wb$styleObjects, function(i) {
+  maxnumFmtId <- max(unlist(sapply(wb$styleObjects, function(i) {
     as.integer(
       max(c(i$style$numFmt$numFmtId, 0))
     )
-  }), 165))
-  
+  })), 165)
+
   
   if ("hyperlink" %in% allColClasses) {
     

--- a/R/helperFunctions.R
+++ b/R/helperFunctions.R
@@ -131,6 +131,14 @@ classStyles <- function(wb, sheet, startRow, startCol, colNames, nRow, colClasse
   newStylesElements <- NULL
   names(colClasses) <- NULL
   
+  # For custom number formats, ensure unique IDs (extract the current maximum and add 1 for each new format)
+  maxnumFmtId <- max(c(sapply(wb$styleObjects, function(i) {
+    as.integer(
+      max(c(i$style$numFmt$numFmtId, 0))
+    )
+  }), 165))
+  
+  
   if ("hyperlink" %in% allColClasses) {
     
     ## style hyperlinks
@@ -153,8 +161,15 @@ classStyles <- function(wb, sheet, startRow, startCol, colNames, nRow, colClasse
     ## style dates
     inds <- which(sapply(colClasses, function(x) "date" %in% x))
     
+    # make sure the style has a unique ID:
+    style = createStyle(numFmt = "date")
+    if (style$numFmt$numFmtId == 165) {
+      style$numFmt$numFmtId <- maxnumFmtId + 1
+      maxnumFmtId <- style$numFmt$numFmtId
+    }
+
     styleElements <- list(
-      "style" = createStyle(numFmt = "date"),
+      "style" = style,
       "sheet" = wb$sheet_names[sheet],
       "rows" = rep.int(rowInds, times = length(inds)),
       "cols" = rep(inds + startCol, each = length(rowInds))
@@ -168,8 +183,15 @@ classStyles <- function(wb, sheet, startRow, startCol, colNames, nRow, colClasse
     ## style POSIX
     inds <- which(sapply(colClasses, function(x) any(c("posixct", "posixt", "posixlt") %in% x)))
     
+    # make sure the style has a unique ID:
+    style = createStyle(numFmt = "LONGDATE")
+    if (style$numFmt$numFmtId == 165) {
+      style$numFmt$numFmtId <- maxnumFmtId + 1
+      maxnumFmtId <- style$numFmt$numFmtId
+    }
+
     styleElements <- list(
-      "style" = createStyle(numFmt = "LONGDATE"),
+      "style" = style,
       "sheet" = wb$sheet_names[sheet],
       "rows" = rep.int(rowInds, times = length(inds)),
       "cols" = rep(inds + startCol, each = length(rowInds))

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -1037,11 +1037,11 @@ addStyle <- function(wb,
 
   if (!is.null(style$numFmt) & length(wb$styleObjects) > 0) {
     if (style$numFmt$numFmtId == 165) {
-      maxnumFmtId <- max(c(sapply(wb$styleObjects, function(i) {
+      maxnumFmtId <- max(unlist(sapply(wb$styleObjects, function(i) {
         as.integer(
           max(c(i$style$numFmt$numFmtId, 0))
         )
-      }), 165))
+      })), 165)
       style$numFmt$numFmtId <- maxnumFmtId + 1
     }
   }


### PR DESCRIPTION
Make sure that writeData with a date creates a style that has no collisions of its numFmtId with existing styles. By default, a style with numFmdId=165 (hard-coded!) is created by createStyle. When inserting that style into a workbook, we need to assign it a new, unique numFmtId if the workbook already has some custom number formats.
The explicitly-called addStyle function checked for this case, but the implicitly-called classStyles function did not.

Fixes #330.