### PR TITLE
Get file mode from output directory and not from tempdir. fix #333

### DIFF
--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -112,8 +112,12 @@ saveWorkbook <- function(wb, file, overwrite = FALSE, returnValue = FALSE) {
 
   xlsx_file <- wb$saveWorkbook()
 
-
-  file.create(file)
+  # file did not exist, create it and overwrite
+  if (!file.exists(file)) {
+    file.create(file)
+    overwrite <- TRUE
+  }
+  
   def_mode <- file.info(file)$mode
   result <- file.copy(from = xlsx_file, to = file, overwrite = overwrite)
   Sys.chmod(file, def_mode)

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -112,16 +112,7 @@ saveWorkbook <- function(wb, file, overwrite = FALSE, returnValue = FALSE) {
 
   xlsx_file <- wb$saveWorkbook()
 
-  # # file did not exist, create it and overwrite
-  # if (!file.exists(file)) {
-  #   file.create(file)
-  #   overwrite <- TRUE
-  # }
-  #
-  # def_mode <- file.info(file)$mode
   result <- file.copy(from = xlsx_file, to = file, overwrite = overwrite, copy.mode = FALSE)
-  # Sys.chmod(file, def_mode, FALSE)
-
 
   ## delete temporary dir
   unlink(dirname(xlsx_file), force = TRUE, recursive = TRUE)

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -112,7 +112,12 @@ saveWorkbook <- function(wb, file, overwrite = FALSE, returnValue = FALSE) {
 
   xlsx_file <- wb$saveWorkbook()
 
+
+  file.create(file)
+  def_mode <- file.info(file)$mode
   result <- file.copy(from = xlsx_file, to = file, overwrite = overwrite)
+  Sys.chmod(file, def_mode)
+
 
   ## delete temporary dir
   unlink(dirname(xlsx_file), force = TRUE, recursive = TRUE)

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -112,15 +112,15 @@ saveWorkbook <- function(wb, file, overwrite = FALSE, returnValue = FALSE) {
 
   xlsx_file <- wb$saveWorkbook()
 
-  # file did not exist, create it and overwrite
-  if (!file.exists(file)) {
-    file.create(file)
-    overwrite <- TRUE
-  }
-  
-  def_mode <- file.info(file)$mode
-  result <- file.copy(from = xlsx_file, to = file, overwrite = overwrite)
-  Sys.chmod(file, def_mode)
+  # # file did not exist, create it and overwrite
+  # if (!file.exists(file)) {
+  #   file.create(file)
+  #   overwrite <- TRUE
+  # }
+  #
+  # def_mode <- file.info(file)$mode
+  result <- file.copy(from = xlsx_file, to = file, overwrite = overwrite, copy.mode = FALSE)
+  # Sys.chmod(file, def_mode, FALSE)
 
 
   ## delete temporary dir


### PR DESCRIPTION
Hi @finalspy, please check if this solves your issue. I am not sure how this affects Windows, but this are base R functions, maybe we are lucky.

If creating the file in `/tmp` is the issue:

1) We write some empty file of the identical name to the output directory.
2) We get the correct access rights.
3) Once the zip file is created, we change the output access rights.
