### PR TITLE
fix clang14 warnings on CRAN

### DIFF
--- a/src/load_workbook.cpp
+++ b/src/load_workbook.cpp
@@ -119,7 +119,7 @@ SEXP loadworksheets(Reference wb, List styleObjects, std::vector<std::string> xm
 
           buf = cols[ci];
           // If either custom widths or groupings, get column index
-          if ((buf.find("customWidth", 0) != string::npos) | (buf.find("outlineLevel", 0) != string::npos)) {
+          if ((buf.find("customWidth", 0) != string::npos) || (buf.find("outlineLevel", 0) != string::npos)) {
             
             tmp_pos = buf.find("min=\"", 0);
             endPos = buf.find(tagEnd, tmp_pos + 5);
@@ -139,7 +139,7 @@ SEXP loadworksheets(Reference wb, List styleObjects, std::vector<std::string> xm
             }
 
             // If column has both a custom width and is part of a group
-            if ((buf.find("customWidth", 0) != string::npos) & (buf.find("outlineLevel", 0) != string::npos)) {
+            if ((buf.find("customWidth", 0) != string::npos) && (buf.find("outlineLevel", 0) != string::npos)) {
               tmp_pos = buf.find("width=\"", 0);
               endPos = buf.find(tagEnd, tmp_pos + 7);
               tmp_width = atof(buf.substr(tmp_pos + 7, endPos - tmp_pos - 7).c_str()) - 0.71;

--- a/src/read_workbook.cpp
+++ b/src/read_workbook.cpp
@@ -637,7 +637,7 @@ SEXP read_workbook(IntegerVector cols_in,
   // Possible there are no string_inds to begin with and value of string_inds is 0
   // Possible we have string_inds but they have now all been used up by headers
   bool allNumeric = false;
-  if((string_inds.size() == 0) | all(is_na(string_inds)))
+  if((string_inds.size() == 0) || is_true(all(is_na(string_inds))))
     allNumeric = true;
   
   if(has_date){
@@ -645,8 +645,8 @@ SEXP read_workbook(IntegerVector cols_in,
       allNumeric = false;
   }
   
-  // If we have colnames some elements where used to create these -so we remove the corresponding number of elements
-  if(hasColNames & has_date)
+  // If we have colnames some elements were used to create these -so we remove the corresponding number of elements
+  if(hasColNames && has_date)
     is_date.erase(is_date.begin(), is_date.begin() + pos);
   
   

--- a/src/write_data.cpp
+++ b/src/write_data.cpp
@@ -103,7 +103,7 @@ IntegerVector build_cell_types_integer(CharacterVector classes, int n_rows){
 
   for(size_t i = 0; i < n_cols; i++){
     
-    if((classes[i] == "numeric") | (classes[i] == "integer") | (classes[i] == "raw") ){
+    if((classes[i] == "numeric") || (classes[i] == "integer") || (classes[i] == "raw") ){
       col_t[i] = 0; 
     }else if(classes[i] == "character"){
       col_t[i] = 1; 
@@ -134,7 +134,7 @@ CharacterVector buildCellTypes(CharacterVector classes, int nRows){
   CharacterVector colLabels(nCols);
   for(int i=0; i < nCols; i++){
     
-    if((classes[i] == "numeric") | (classes[i] == "integer") | (classes[i] == "raw") ){
+    if((classes[i] == "numeric") || (classes[i] == "integer") || (classes[i] == "raw") ){
       colLabels[i] = "n"; 
     }else if(classes[i] == "character"){
       colLabels[i] = "s"; 

--- a/src/write_file.cpp
+++ b/src/write_file.cpp
@@ -254,7 +254,7 @@ SEXP buildMatrixMixed(CharacterVector v,
       bool logCol = true;
       for(int ri = 0; ri < nRows; ri++){
         if(notNAElements[ri]){
-          if((m(ri, i) != "TRUE") & (m(ri, i) != "FALSE")){
+          if((m(ri, i) != "TRUE") && (m(ri, i) != "FALSE")){
             logCol = false;
             break;
           }


### PR DESCRIPTION
This fixes the clang14 warnigns: `use of bitwise with boolean operands` reported by CRAN. (I was unable to locate this: write_file.cpp:251, but fixed a line few lines below the reported, but was to lazy to check if we modified the code since the last release).

https://cran.r-project.org/web/checks/check_results_openxlsx.html