### PR TITLE
issue 342

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 Language: en-US
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Collate: 
     'CommentClass.R'
     'HyperlinkClass.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 
 ## Fixes
 
-* `openxlsx_setOp()` now works with named list ([#215](https://github.com/ycphs/openxlsx/issues/215))  
+* `openxlsx_setOp()` now works with named list ([#215](https://github.com/ycphs/openxlsx/issues/215))
 * `loadWorkbook()` imports `inlineStr`. Values remain `inlineStr` when writing the workbook with `saveWorkbook()`. Similar `read.xlsx` and `readWorkbook` import `inlineStr`.
 * `read.xlsx()` no longer changes random seed ([#183](https://github.com/ycphs/openxlsx/issues/183))
 * fixed a regression that caused fonts to be read in incorrectly ([#207](https://github.com/ycphs/openxlsx/issues/207))
@@ -383,7 +383,7 @@
 *  functions `addFilter` & `removeFilter` to add filters to columns
 
 *  Headers & footers extended, can now be set with `addWorksheet` and `setHeaderFooter`.
-  `setHeader` & `setFooter` deprecated.  
+  `setHeader` & `setFooter` deprecated.
 
 *  "fitToWidth" and "fitToHeight" logicals in `pageSetup`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # openxlsx (development version)
 
+* Fixed warning on `dataValidation(..., type = "list")` ([#342](https://github.com/ycphs/openxlsx/issues/342))
+
 ## Improvements
 
 * Improve detectDates ([#288](https://github.com/ycphs/openxlsx/issues/288))

--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -2569,8 +2569,7 @@ Workbook$methods(
         '<x14:dataValidation type="list" allowBlank="%s" showInputMessage="%s" showErrorMessage="%s">',
         allowBlank,
         showInputMsg,
-        showErrorMsg,
-        sqref
+        showErrorMsg
       )
 
     formula <-

--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -37,7 +37,7 @@ Workbook$methods(
     headFoot <<- NULL
 
     media <<- list()
-    
+
     persons <<- NULL
 
     pivotTables <<- NULL
@@ -56,7 +56,7 @@ Workbook$methods(
 
     sheet_names <<- character(0)
     sheetOrder <<- integer(0)
-   
+
     sharedStrings <<- list()
     attr(sharedStrings, "uniqueCount") <<- 0
 
@@ -106,7 +106,7 @@ Workbook$methods(
       }
     }
     newSheetIndex <- length(worksheets) + 1L
-    
+
     if (newSheetIndex > 1) {
       sheetId <-
         max(as.integer(regmatches(
@@ -121,7 +121,7 @@ Workbook$methods(
 
     ## fix visible value
     visible <- tolower(visible)
-    
+
     if (visible == "true") {
       visible <- "visible"
     } else if (visible == "false") {
@@ -129,7 +129,7 @@ Workbook$methods(
     } else if (visible == "veryhidden") {
       visible <- "veryHidden"
     }
-    
+
     ##  Add sheet to workbook.xml
     workbook$sheets <<-
       c(
@@ -678,12 +678,12 @@ Workbook$methods(
 
       .self$writeDrawingVML(xldrawingsDir)
     }
-    
+
     ## Threaded Comments xl/threadedComments/threadedComment.xml
     if (nThreadComments > 0){
       xlThreadComments <- file.path(tmpDir, "xl", "threadedComments")
       dir.create(path = xlThreadComments, recursive = TRUE)
-      
+
       for (i in seq_len(nSheets)) {
         if (length(threadComments[[i]]) > 0) {
           fl <- threadComments[[i]]
@@ -714,10 +714,10 @@ Workbook$methods(
         to = personDir,
         overwrite = TRUE
       )
-      
+
     }
-    
-    
+
+
     if (length(embeddings) > 0) {
       embeddingsDir <- file.path(tmpDir, "xl", "embeddings")
       dir.create(path = embeddingsDir, recursive = TRUE)
@@ -1179,7 +1179,7 @@ Workbook$methods(
       )
     # because tableName might be native encoded non-ASCII strings, we need to ensure
     # it's UTF-8 encoded
-    table <- enc2utf8(table) 
+    table <- enc2utf8(table)
 
     nms <- names(tables)
     tSheets <- attr(tables, "sheet")
@@ -1768,7 +1768,7 @@ Workbook$methods(
     if ("ACCOUNTING2" %in% style$fontDecoration) {
       fontNode <- stri_join(fontNode, '<u val="doubleAccounting"/>')
     }
-    
+
     if ("STRIKEOUT" %in% style$fontDecoration) {
       fontNode <- stri_join(fontNode, "<strike/>")
     }
@@ -1985,7 +1985,7 @@ Workbook$methods(
                                xlworksheetsRelsDir) {
     ## write worksheets
     # nSheets <- length(worksheets)
-    
+
     for (i in seq_along(worksheets)) {
       ## Write drawing i (will always exist) skip those that are empty
       if (any(drawings[[i]] != "")) {
@@ -2183,7 +2183,7 @@ Workbook$methods(
 
     hidden <- attr(colOutlineLevels[[sheet]], "hidden", exact = TRUE)
     cols <- names(colOutlineLevels[[sheet]])
-    
+
     if (!grepl("outlineLevelCol", worksheets[[sheet]]$sheetFormatPr)) {
       worksheets[[sheet]]$sheetFormatPr <<- sub("/>", ' outlineLevelCol="1"/>', worksheets[[sheet]]$sheetFormatPr)
     }
@@ -2622,10 +2622,10 @@ Workbook$methods(
             )
           )
         priority_new <- as.integer(priority) + 1L
-        
+
         priority_pattern <- sprintf('priority="%s"', priority)
         priority_new <- sprintf('priority="%s"', priority_new)
-        
+
         ## now replace
         worksheets[[sheet]]$conditionalFormatting[[i]] <<-
           gsub(priority_pattern,
@@ -2814,7 +2814,7 @@ Workbook$methods(
                        </cfRule>',
           dxfId,
           values,
-          
+
           unlist(strsplit(sqref, split = ":"))[[1]],
           values,
           values
@@ -2827,7 +2827,7 @@ Workbook$methods(
                        </cfRule>',
           dxfId,
           values,
-          
+
           unlist(strsplit(sqref, split = ":"))[[1]],
           values,
           values
@@ -3251,7 +3251,7 @@ Workbook$methods(
         visible_sheet_index - 1L,
         ActiveSheet - 1L
       )
-    
+
     for(i in seq_len(nSheets)) {
       worksheets[[i]]$sheetViews <<-
         sub(
@@ -3266,7 +3266,7 @@ Workbook$methods(
         )
     }
     # worksheets[[visible_sheet_index]]$sheetViews
-    
+
     # worksheets[[visible_sheet_index]]$sheetViews <<-
     #   sub(
     #     '( tabSelected="0")|( tabSelected="false")',
@@ -3459,8 +3459,8 @@ Workbook$methods(
       if (length(colOutlineLevels[[i]]) > 0) {
         invisible(.self$groupColumns(i))
       }
-      
-      
+
+
       if(ActiveSheet==i) {
         worksheets[[sheetOrder[i]]]$sheetViews <<-
           stri_replace_all_regex(
@@ -3733,7 +3733,7 @@ Workbook$methods(
     aSheet <- ActiveSheet
     exSheets <- replaceXMLEntities(exSheets)
     showText <- "A Workbook object.\n"
-    
+
     if (length(aSheet) == 0) {
       aSheet <- 1
     }
@@ -3847,9 +3847,9 @@ Workbook$methods(
           stri_join(sheetOrder, sep = " ", collapse = ", ")
         ))
     }
-    
-    
-    
+
+
+
     if (aSheet >= 1 & nSheets > 0) {
       showText <-
         c(
@@ -4374,11 +4374,11 @@ Workbook$methods(
                            paste0("tabSelected=\"",
                                   ifelse(sheetOrder[ActiveSheet]  == i,"true","false")
                                   ,"\""))
-      
-      
+
+
     }
-    
-    
-  
+
+
+
   }
 )

--- a/tests/testthat/test-validate_data.R
+++ b/tests/testthat/test-validate_data.R
@@ -1,0 +1,19 @@
+context("Data validation")
+
+# Basic test workbook ==========================================================
+
+wb <- createWorkbook()
+addWorksheet(wb, "Sheet 1")
+addWorksheet(wb, "Sheet 2")
+writeDataTable(wb, sheet = 1, x = iris[1:30, ])
+writeData(wb, sheet = 2, x = sample(iris$Sepal.Length, 10))
+
+# Unit tests ===================================================================
+
+test_that("Data validation for lists is performed without warnings", {
+  expect_invisible(
+    dataValidation(
+      wb, 1, col = 1, rows = 2:31, type = "list", value = "'Sheet 2'!$A$1:$A$10"
+    )
+  )
+})


### PR DESCRIPTION
Fixes issue #342, resolving a warning when using `dataValidation(type = "list", ...)`. Whitespace removal was automatically done by my IDE, and RoxygenNote version update was done by `devtools::check()`.

- Whitespace removal
- RoxygenNote version update
- Fixes warning on dataValidation for lists (#342)
- Added unit test for #342
- Updated NEWS.md
