### PR TITLE
Check tmpDir with dir.exists() and create tmpDir non-recursively

### DIFF
--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -562,7 +562,7 @@ Workbook$methods(
     ## temp directory to save XML files prior to compressing
     tmpDir <- file.path(tempfile(pattern = "workbookTemp_"))
 
-    if (file.exists(tmpDir)) {
+    if (dir.exists(tmpDir)) {
       unlink(tmpDir, recursive = TRUE, force = TRUE)
     }
 

--- a/R/WorkbookClass.R
+++ b/R/WorkbookClass.R
@@ -566,7 +566,7 @@ Workbook$methods(
       unlink(tmpDir, recursive = TRUE, force = TRUE)
     }
 
-    success <- dir.create(path = tmpDir, recursive = TRUE)
+    success <- dir.create(path = tmpDir, recursive = FALSE)
     if (!success) {
       stop(sprintf("Failed to create temporary directory '%s'", tmpDir))
     }


### PR DESCRIPTION
The creation of `tmpDir` fails, when the Windows system variables TEMP/TMP are set to the root directory of an (external) drive:

![EnvironmentalVariables_Windows10](https://user-images.githubusercontent.com/19319377/177663175-0ebf0577-79e3-4ebe-8925-c4500e793731.PNG)

```R console
Warning in dir.create(path = tmpDir, recursive = TRUE) :
  cannot create dir 'T:\', reason 'Permission denied'
```

`tempDir()` and `file.path(tempDir())` return the same temporary path, which leads to the described error:
```R console
> tempdir()
[1] "T:\\\\Rtmp00GJkQ"
> file.path(tempdir())
[1] "T:\\\\Rtmp00GJkQ"
```
When `dir.create` tries to recursively create the directory structure, it fails because it cannot access the mounting point of the drive ("drive letter with separator") for writing - while any files and folders placed at the root directory level are fully accessible with the respective file system permissions granted:
```R console
> tmpDir <- tempfile(pattern = "workbookTemp_", tmpdir = "T:\\")
> 
> dir.create(path = tmpDir, recursive = FALSE) # works
>
> dir.create(path = tmpDir, recursive = TRUE)  # fails
Warning message:
In dir.create(path = tmpDir, recursive = TRUE) :
  cannot create dir 'T:\', reason 'Permission denied'
>
```
Interestingly, the recursive creation of the `tmpDir` works when the `tmpdir` variable is set to `T:` instead of `T:\`.
```R console
> tmpDir <- tempfile(pattern = "workbookTemp_", tmpdir = "T:")
> dir.create(path = tmpDir, recursive = TRUE)
> 
```

There are two possible workarounds without altering the code:

1. Parsing the paths of TEMP/TMP before passing to `tempfile`, and
2. moving the TEMP/TMP paths to subdirectories of the (external) drive.

However, both options mask another problem with the current code:

In the [`saveWorkBook`](https://github.com/ycphs/openxlsx/blob/a4c60726899e0af75b208912dc37dd342742b709/R/WorkbookClass.R#L561) function of `WorkbookClass.R`, we are creating a single folder in the system's temp directory: There is no need to recursively create the directory structure for a single folder.

The system's temp folder is automatically created by `tempfile(pattern = "file", tmpdir = tempdir())`, see [documentation](url):

> By default, tmpdir will be the directory given by tempdir(). This will be a subdirectory of the per-session temporary directory found by the following rule when the R session is started. The environment variables TMPDIR, TMP and TEMP are checked in turn and the first found which points to a writable directory is used: if none succeeds /tmp is used. The path should not contain spaces. if none succeeds the value of R_USER (see [Rconsole](https://www.rdocumentation.org/link/Rconsole?package=base&version=3.6.2)) is used. If the path to the directory contains a space in any of the components, the path returned will use the shortnames version of the path. Note that setting any of these environment variables in the R session has no effect on tempdir(): the per-session temporary directory is created before the interpreter is started.

The second change to the code is addressing an issue with `file.exists` (see: [docs](https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/files)) and directories:

> Note that the existence of a file does not imply that it is readable: for that use [file.access](https://www.rdocumentation.org/link/file.access?package=base&version=3.6.2).) What constitutes a ‘file’ is system-dependent, _but should include directories_. (However, directory names must not include a trailing backslash or slash on Windows.)

A better function to check if a directory exists would be `dir.exists` (see `?dir.exists`:
> dir.exists checks that the paths exist (in the same sense as file.exists) and are directories.

Please consider these code changes for review.