### PR TITLE
add missing }

### DIFF
--- a/vignettes/Introduction.Rmd
+++ b/vignettes/Introduction.Rmd
@@ -505,6 +505,6 @@ file_list<-fl[!grepl("inst/extdata",file_list)&!grepl("man/",file_list)]
 if(length(file_list)>0){
 rm(file_list)
 }
-
+}
 ```
 


### PR DESCRIPTION
This is causing `lintr` to hang on `openxlsx`:

https://github.com/r-lib/lintr/issues/1443

We'll try and fix the lintr not to fail so gracelessly, but in the meantime, this will un-stick the linter from working.