### PR TITLE
replace sprintf with snprintf

### DIFF
--- a/src/read_workbook.cpp
+++ b/src/read_workbook.cpp
@@ -550,20 +550,14 @@ SEXP read_workbook(IntegerVector cols_in,
       
       if(missing_header[i]){  // a missing header element
         
-        sprintf(&(name[0]), "X%d", i+1);
-        // sprintf(&(name[0]), "X%u", i+1);
-        // snprintf(&(name[0]), sizeof(&(name[0])), "X%d", i+1);
-        // snprintf(&(name[0]), 10, "X%d", i+1);
+        snprintf(&(name[0]), 6, "X%d", i+1);
         col_names[i] = name;
         
       }else{  // this is a header elements 
         
         col_names[i] = v[pos];
         if(col_names[i] == "NA"){
-          sprintf(&(name[0]), "X%d", i+1);
-          // sprintf(&(name[0]), "X%d", i+1);
-          // snprintf(&(name[0]), sizeof(&(name[0])), "X%d", i+1);
-          // snprintf(&(name[0]), 10, "X%d", i+1);
+          snprintf(&(name[0]), 6, "X%d", i+1);
           col_names[i] = name;
         }
         
@@ -620,9 +614,7 @@ SEXP read_workbook(IntegerVector cols_in,
   }else{ // else col_names is FALSE
     char name[6];
     for(int i =0; i < nCols; i++){
-      sprintf(&(name[0]), "X%d", i+1);
-       // snprintf(&(name[0]), sizeof(&(name[0])), "X%d", i+1);
-      // sprintf(&(name[0]), "X%u", i+1);
+      snprintf(&(name[0]), 6, "X%d", i+1);
       col_names[i] = name;
     }
   }

--- a/src/write_data.cpp
+++ b/src/write_data.cpp
@@ -195,7 +195,7 @@ List build_cell_merges(List comps){
     for(size_t j = 0; j < ck; j++){
       for(size_t k = 0; k < rk; k++){
         char name[30];
-        sprintf(&(name[0]), "%d-%d", r[k], v[j]);
+        snprintf(&(name[0]), 30, "%d-%d", r[k], v[j]);
         M(ind) = name;
         ind++;
       }


### PR DESCRIPTION
Should fix these [warnings](https://www.stats.ox.ac.uk/pub/bdr/M1mac/openxlsx.out). Though I haven't really checked if they work as intended.

```txt
Found the following significant warnings:
  /Users/ripley/R/Library/Rcpp/include/Rcpp/internal/r_coerce.h:255:7: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  read_workbook.cpp:553:2: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  read_workbook.cpp:563:4: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  read_workbook.cpp:623:7: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  write_data.cpp:198:9: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
```