### PR TITLE
add C++11 as a req. to `DESCRIPTION`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,6 +53,7 @@ Suggests:
     testthat
 LinkingTo: 
     Rcpp
+SystemRequirements: C++11
 VignetteBuilder: 
     knitr
 Encoding: UTF-8


### PR DESCRIPTION
Fixes #396 

(This is my first contribution to this project, I hope it is okay)

As the associated issue states, I'm unable to build this package as of tag 4.2.5 (but 4.2.4 works). Some digging makes me believe it was the new use of `auto` here:
https://github.com/ycphs/openxlsx/compare/v4.2.4...v4.2.5#diff-b6d57bccb15a01d2c62f239b2a082c0df403ac0c6244c1d42282f9ca748d6a20R925

which requires C++11. I simply added it to the `DESCRIPTION` file and it successfully built from source.

Also tested on my Windows machine successfully.

```r
# all passed
devtools::check()
```