### PR TITLE
fix: Avoid adding an <sheetPr></sheetPr> when not needed

### DIFF
--- a/R/worksheet_class.R
+++ b/R/worksheet_class.R
@@ -100,7 +100,7 @@ WorkSheet$methods(get_prior_sheet_data = function() {
 
   if (length(sheetPr) > 0) {
     tmp <- sheetPr
-    if (!any(grepl("<sheetPr>", tmp, fixed = TRUE))) {
+    if (!any(grepl("<sheetPr", tmp, fixed = TRUE))) {
       tmp <- paste0("<sheetPr>", paste(tmp, collapse = ""), "</sheetPr>")
     }
 


### PR DESCRIPTION
Replaces pull request https://github.com/ycphs/openxlsx/pull/404 

Thanks you very much @JanMarvin for your reply and your insights (https://github.com/ycphs/openxlsx/pull/404). It made me curious why there is a nested  `<sheetPr>` tag. Adjusted my pull request; now checking if there is any `<sheetPr>` or `<sheetPr ...>`. If not, it would be added.

**Testing**

I have tested the change following the minimal posted in issue https://github.com/ycphs/openxlsx/issues/403

* On both Windows 10 and Ubuntu 22.04
* Both starting with an Excel file as well as a libreoffice XLSX file (once saved via Excel, once saved via libreoffice)
* Yields 4 unique combinations

Under all circumstances `openxlsx::read.xlsx`, `readxl::read_excel`, Libreoffice, as well as Excel were able to read the sheets as expected.

Thanks a lot!