### PR TITLE
Improve offline testing

### DIFF
--- a/tests/testthat/test-read_sources.R
+++ b/tests/testthat/test-read_sources.R
@@ -8,6 +8,7 @@ context("Read Sources")
 
 
 test_that("read.xlsx from different sources", {
+  skip_if_offline()
 
   ## URL
   xlsxFile <- "https://github.com/ycphs/openxlsx/raw/master/inst/extdata/readTest.xlsx"
@@ -34,6 +35,7 @@ test_that("read.xlsx from different sources", {
 
 
 test_that("loadWorkbook from different sources", {
+  skip_if_offline()
 
   ## URL
   xlsxFile <- "https://github.com/ycphs/openxlsx/raw/master/inst/extdata/readTest.xlsx"
@@ -50,6 +52,7 @@ test_that("loadWorkbook from different sources", {
 
 
 test_that("getDateOrigin from different sources", {
+  skip_if_offline()
 
   ## URL
   xlsxFile <- "https://github.com/ycphs/openxlsx/raw/master/inst/extdata/readTest.xlsx"


### PR DESCRIPTION
This pull request improves the handling of offline scenarios in tests that require an internet connection.

Specifically, it adds a `skip_if_offline()` call to these tests, which will prevent them from running when there is no internet connection detected.

This change improves the resilience of the unit tests and make it easier for people to run tests in different environments such as air gapped ones.