### PR TITLE
Remove dependency on roxygen2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,6 @@ Imports:
 Suggests:
     knitr,
     rmarkdown,
-    roxygen2,
     testthat
 LinkingTo: 
     Rcpp


### PR DESCRIPTION
The RoxygenNote field is sufficient, as roxygen2 is only a development dependency.