### PR TITLE
Coerce matrix to data.frame in writexlsx.R

### DIFF
--- a/R/writexlsx.R
+++ b/R/writexlsx.R
@@ -60,6 +60,9 @@
 #'
 #' @export
 write.xlsx <- function(x, file, asTable = FALSE, overwrite = TRUE, ...) {
+  if ("matrix" %in% class(x)){
+    x <- as.data.frame(x)
+  }
   wb <- buildWorkbook(x, asTable = asTable, ...)
   saveWorkbook(wb, file = file, overwrite = overwrite)
   invisible(wb)


### PR DESCRIPTION
write.xlsx produces empty or incorrectly formatted files if the argument is a matrix instead of a data frame. This is one potential workaround for a (potentially) common mistake in usage. An alternative approach would be to more explicitly enforce the type of the `x` argument. 

Simple example which will silently fail without something like the embedded commit:

```
library(openxlsx)
X <- matrix(rnorm(100), ncol = 10)
write.xlsx(X, file = "tmp.xlsx", replace = TRUE)
```