### PR TITLE
Fix rdevel segfaults2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,11 +2,13 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master, development]
+    branches: [main, master]
   pull_request:
-    branches: [main, master, development]
+    branches: [main, master]
 
 name: lint
+
+permissions: read-all
 
 jobs:
   lint:
@@ -14,7 +16,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -28,3 +30,5 @@ jobs:
       - name: Lint
         run: lintr::lint_package()
         shell: Rscript {0}
+        env:
+          LINTR_ERROR_ON_LINT: true

--- a/.lintr
+++ b/.lintr
@@ -10,8 +10,6 @@ linters: linters_with_defaults(
   function_left_parentheses_linter = NULL, #
   spaces_inside_linter = NULL,             #
   spaces_left_parentheses_linter = NULL,   #
-  no_tab_linter = NULL,                    #
-  single_quotes_linter = NULL,             #
   object_length_linter = NULL,             #
   assignment_linter = NULL                 # just one case
   )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,6 +51,7 @@ Imports:
     utils,
     zip
 Suggests:
+    curl,
     knitr,
     rmarkdown,
     testthat


### PR DESCRIPTION
Hi @ycphs , your merge was a little to quick for me :)

I wanted to at least make the CI pass. There are a bunch of `lintr` and remaining other issues that I wont tackle. I was just curious to see if the segfault can be fixed and doing my part to keep the package on CRAN.

Fingers crossed that it will build now run without errors.
