### PR TITLE
fix loading "loadExample.xlsx"

### DIFF
--- a/R/loadWorkbook.R
+++ b/R/loadWorkbook.R
@@ -609,7 +609,11 @@ loadWorkbook <- function(file, xlsxFile = NULL, isUnzipped = FALSE) {
       wb$Content_Types <- c(wb$Content_Types, sprintf('<Override PartName="/xl/slicerCaches/slicerCache%s.xml" ContentType="application/vnd.ms-excel.slicerCache+xml"/>', inds))
       wb$slicerCaches <- sapply(slicerCachesXML[order(nchar(slicerCachesXML), slicerCachesXML)], function(x) removeHeadTag(cppReadFile(x)))
       wb$workbook.xml.rels <- c(wb$workbook.xml.rels, sprintf('<Relationship Id="rId%s" Type="http://schemas.microsoft.com/office/2007/relationships/slicerCache" Target="slicerCaches/slicerCache%s.xml"/>', 1E5 + inds, inds))
-      wb$workbook$extLst <- c(wb$workbook$extLst, genSlicerCachesExtLst(1E5 + inds))
+      
+      if (!grepl("slicerCaches", wb$workbook$extLst))
+        wb$workbook$extLst <- c(wb$workbook$extLst, genSlicerCachesExtLst(1E5 + inds))
+      else
+        wb$workbook$extLst <- genSlicerCachesExtLst(1E5 + inds)
     }
 
 


### PR DESCRIPTION
*\*sigh\**

Let this be my final bugfix. I tried the `loadWorkbook()` example, but the file failed to open in MS365. This PR hotfixes this, plain and simple.