### PR TITLE
fix sharedString deletion

### DIFF
--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -1916,14 +1916,17 @@ deleteDataColumn <- function(wb, sheet, col) {
   a$rows <- a$rows[keep]
 
   # reduce the shared strings pointers if they are not used anymore
-  ss <- data.frame(
-    # the old index 0 indexed, as used in a$v
-    old = as.numeric(seq(length(wb$sharedStrings)) - 1),
-    # will hold the new index 0 indexed, as used in a$v
-    new = NA,
-    # the actual strings
-    string = wb$sharedStrings
-  )
+  ss <- data.frame(old = numeric(0), new = numeric(0), string = character(0))
+  if (length(wb$sharedStrings) > 0) {
+    ss <- data.frame(
+      # the old index 0 indexed, as used in a$v
+      old = as.numeric(seq(length(wb$sharedStrings)) - 1),
+      # will hold the new index 0 indexed, as used in a$v
+      new = NA,
+      # the actual strings
+      string = wb$sharedStrings
+    )
+  }
   
   # 1. remove the values from sheet_data (a)
   a$v <- a$v[keep]

--- a/tests/testthat/test-wrappers.R
+++ b/tests/testthat/test-wrappers.R
@@ -2,22 +2,22 @@
 context("Test wrappers")
 
 test_that("int2col and col2int", {
-  
+
   nums <- 2:27
-  
+
   chrs <- c("B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",  "N",
             "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "AA")
-  
+
   expect_equal(chrs, int2col(nums))
   expect_equal(nums, col2int(chrs))
-  
+
 })
 
 
 test_that("deleteDataColumn basics", {
   wb <- createWorkbook()
   addWorksheet(wb, "tester")
-  
+
   for (i in seq(5)) {
     mat <- data.frame(x = rep(paste0(int2col(i), i), 10))
     writeData(wb, sheet = 1, startRow = 1, startCol = i, mat)
@@ -29,8 +29,8 @@ test_that("deleteDataColumn basics", {
     c("<f>=COUNTA(A2:A11)</f>", "<f>=COUNTA(B2:B11)</f>", "<f>=COUNTA(C2:C11)</f>", 
       "<f>=COUNTA(D2:D11)</f>", "<f>=COUNTA(E2:E11)</f>")
   )
-  
-  
+
+
   deleteDataColumn(wb, 1, col = 3)
   expect_equal(read.xlsx(wb),
                data.frame(x = rep("A1", 10), x = "B2", x = "D4", x = "E5", # no C3!
@@ -40,8 +40,8 @@ test_that("deleteDataColumn basics", {
     c("<f>=COUNTA(A2:A11)</f>", "<f>=COUNTA(B2:B11)</f>", 
       "<f>=COUNTA(C2:C11)</f>", "<f>=COUNTA(D2:D11)</f>")
   )
-  
-  
+
+
   deleteDataColumn(wb, 1, col = 2)
   expect_equal(read.xlsx(wb),
                data.frame(x = rep("A1", 10), x = "D4", x = "E5", # no B2!
@@ -50,7 +50,7 @@ test_that("deleteDataColumn basics", {
     setdiff(wb$worksheets[[1]]$sheet_data$f, NA),
     c("<f>=COUNTA(A2:A11)</f>", "<f>=COUNTA(B2:B11)</f>", "<f>=COUNTA(C2:C11)</f>")
   )
-  
+
   deleteDataColumn(wb, 1, col = 1)
   expect_equal(read.xlsx(wb),
                data.frame(x = rep("D4", 10), x = "E5", # no A1!
@@ -68,22 +68,22 @@ test_that("deleteDataColumn with more complicated formulae", {
   addWorksheet(wb, "tester")
   writeData(wb, sheet = 1, startRow = 1, startCol = 1,
             x = matrix(c(1, 1), ncol = 1), colNames = FALSE)
-  
+
   for (c in 2:10)
     writeFormula(wb, 1, sprintf("%s1 + 1", int2col(c - 1)),
                  startRow = 1, startCol = c)
-  
+
   for (c in 2:10)
     writeFormula(wb, 1, sprintf("%s1 + %s2", int2col(c), int2col(c - 1)),
                  startRow = 2, startCol = c)
-  
+
   for (c in 2:10)
     writeFormula(wb, 1, sprintf("%s2 + %s2", int2col(c), int2col(c + 1)),
                  startRow = 3, startCol = c)
-  
+
   deleteDataColumn(wb, 1, 3)
   # saveWorkbook(wb, "tester.xlsx") # and inspect by hand: expect lots of #REF!
-  
+
   expect_equal(read.xlsx(wb), data.frame(`1` = 1, check.names = FALSE))
   expect_equal(
     wb$worksheets[[1]]$sheet_data$f,
@@ -103,19 +103,19 @@ test_that("deleteDataColumn with wide data", {
   colnames(df) <- int2col(seq(ncols))
   writeData(wb, sheet = 1, startRow = 1, startCol = 1, x = df, colNames = TRUE)
   expect_equal(read.xlsx(wb), df)
-  
+
   deleteDataColumn(wb, 1, 2)
   expect_equal(read.xlsx(wb), df[, -2])
-  
+
   deleteDataColumn(wb, 1, 100)
   expect_equal(read.xlsx(wb), df[, -2])
-  
+
   deleteDataColumn(wb, 1, 55)
   expect_equal(read.xlsx(wb), df[, -c(2, 56)]) # 56 b.c. one col was already taken out
-  
+
   deleteDataColumn(wb, 1, 1)
   expect_equal(read.xlsx(wb), df[, -c(1, 2, 56)])
-  
+
   # delete all data
   for (i in seq(ncols - 2))
     deleteDataColumn(wb, 1, 1)
@@ -127,15 +127,15 @@ test_that("deleteDataColumn with formatting data", {
   addWorksheet(wb, "tester")
   df <- data.frame(x = 1:10, y = letters[1:10], z = 10:1)
   writeData(wb, sheet = 1, startRow = 1, startCol = 1, x = df, colNames = TRUE)
-  
+
   st <- openxlsx::createStyle(textDecoration = "Bold", fontSize = 20, fontColour = "red")
   openxlsx::addStyle(wb, 1, style = st, rows = 1, cols = seq(ncol(df)))
-  
+
   sst <- wb$styleObjects[[1]]
   sst$rows <- c(1, 1)
   sst$cols <- c(1, 2)
   deleteDataColumn(wb, 1, 2)
-  
+
   expect_length(wb$styleObjects, 1)
   expect_equal(wb$styleObjects[[1]],
                sst)
@@ -146,13 +146,13 @@ test_that("deleteDataColumn with shared strings does not crash or change inputs"
                    "Col 2" = "Row 2 Col 2",
                    "Col 3" = "Row 2 Col 3",
                    check.names = FALSE)
-  
+
   wb <- createWorkbook()
   addWorksheet(wb, "tester")
   writeData(wb, sheet = 1, startRow = 1, startCol = 1, x = df, colNames = TRUE)
-  
+
   deleteDataColumn(wb, sheet =  1, col =  2)
-  
+
   expect_equal(
     wb$sharedStrings,
     structure(
@@ -178,11 +178,11 @@ test_that("deleteDataColumn with shared strings does not crash or change inputs"
 test_that("deleteDataColumn with shared strings on other sheets", {
   df <- data.frame("ABC" = "I am a shared string with sheet 2!")
   df2 <- data.frame("AB" = "I am a shared string with sheet 2!")
-  
+
   wb <- createWorkbook()
   addWorksheet(wb, "tester")
   writeData(wb, sheet = 1, startRow = 1, startCol = 1, x = df, colNames = TRUE)
-  
+
   simplify <- function(sd) data.frame(rows = sd$rows, cols = sd$cols, t = sd$t, v = sd$v)
   expect_equal(
     simplify(wb$worksheets[[1]]$sheet_data),
@@ -198,10 +198,10 @@ test_that("deleteDataColumn with shared strings on other sheets", {
       uniqueCount = 2L
     )
   )
-  
+
   addWorksheet(wb, "tester2")
   writeData(wb, sheet = 2, startRow = 1, startCol = 1, x = df2, colNames = TRUE)
-  
+
   expect_equal(
     simplify(wb$worksheets[[2]]$sheet_data),
     data.frame(rows = c(1, 2), cols = 1, t = 1, v = c("2", "1"))
@@ -217,22 +217,22 @@ test_that("deleteDataColumn with shared strings on other sheets", {
       uniqueCount = 3L
     )
   )
-  
-  
+
+
   # deleting from sheet 1 does not delete the string from sheet 2!
   deleteDataColumn(wb, sheet =  1, col =  1)
-  
+
   expect_equal(
     simplify(wb$worksheets[[1]]$sheet_data),
     data.frame(rows = numeric(0), cols = numeric(0), t = numeric(0), v = character(0))
   )
-  
+
   # note on sheet 2, the indices v to the shared strings have to change as well!
   expect_equal(
     simplify(wb$worksheets[[2]]$sheet_data),
     data.frame(rows = c(1, 2), cols = 1, t = 1, v = c("1", "0"))
   )
-  
+
   expect_equal(
     wb$sharedStrings,
     structure(
@@ -243,7 +243,7 @@ test_that("deleteDataColumn with shared strings on other sheets", {
       uniqueCount = 2L
     )
   )
-  
+
   expect_equal(
     read.xlsx(wb, sheet = 2),
     data.frame(AB = "I am a shared string with sheet 2!")


### PR DESCRIPTION
Fixes #514 

Also adds additional tests for the shared string usecase.

Makes the deleteDataColumn code a little bit easier to read and maintain.

Fixes another bug with sharedStrings across sheets. Now sharedStrings are fixed on a workbook-level and not sheet-level.