### PR TITLE
Add overwrite support to writeData for clean rewrite workflows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 # openxlsx 4.2.8.1
 
 * Fix for upcoming `testthat` release (@hadley, [#530](https://github.com/ycphs/openxlsx/pull/530))
+* Add overwrite support to writeData() to clear stale cells when rewriting with a smaller data range ([#536](https://github.com/ycphs/openxlsx/pull/536))
 
 # openxlsx 4.2.8
 

--- a/R/writeData.R
+++ b/R/writeData.R
@@ -45,6 +45,7 @@
 #' @param na.string If not NULL, and if `keepNA` is `TRUE`, NA values are converted to this string in Excel.
 #' @param name If not NULL, a named region is defined.
 #' @param sep Only applies to list columns. The separator used to collapse list columns to a character vector e.g. sapply(x$list_column, paste, collapse = sep).
+#' @param overwrite If `TRUE`, remove existing cell values in the target worksheet before writing `x`.
 #' @seealso [writeDataTable()]
 #' @export writeData
 #' @details Formulae written using writeFormula to a Workbook object will not get picked up by read.xlsx().
@@ -176,7 +177,8 @@ writeData <- function(
   name         = NULL,
   sep          = ", ",
   col.names,
-  row.names
+  row.names,
+  overwrite    = FALSE
 ) {
 
   x <- force(x)
@@ -224,6 +226,7 @@ writeData <- function(
   assert_class(wb, "Workbook")
   assert_true_false(colNames)
   assert_true_false(rowNames)
+  assert_true_false(overwrite)
   assert_character1(sep)
   assert_class(headerStyle, "Style", or_null = TRUE)
 
@@ -294,6 +297,18 @@ writeData <- function(
 
   if (wb$isChartSheet[[sheetX]]) {
     stop("Cannot write to chart sheet.")
+  }
+
+
+  if (overwrite) {
+    sheet_data <- wb$worksheets[[sheetX]]$sheet_data
+    if (sheet_data$n_elements > 0) {
+      sheet_data$delete(
+        rows_in = sheet_data$rows,
+        cols_in = sheet_data$cols,
+        grid_expand = FALSE
+      )
+    }
   }
 
   ## Check not overwriting existing table headers

--- a/R/writeData.R
+++ b/R/writeData.R
@@ -299,6 +299,14 @@ writeData <- function(
     stop("Cannot write to chart sheet.")
   }
 
+  ## Check not overwriting existing table headers
+  wb$check_overwrite_tables(
+    sheet                   = sheet,
+    new_rows                = c(startRow, startRow + nRow - 1L + colNames),
+    new_cols                = c(startCol, startCol + nCol - 1L),
+    check_table_header_only = TRUE,
+    error_msg               = "Cannot overwrite table headers. Avoid writing over the header row or see getTables() & removeTables() to remove the table object."
+  )
 
   if (overwrite) {
     sheet_data <- wb$worksheets[[sheetX]]$sheet_data
@@ -310,15 +318,6 @@ writeData <- function(
       )
     }
   }
-
-  ## Check not overwriting existing table headers
-  wb$check_overwrite_tables(
-    sheet                   = sheet,
-    new_rows                = c(startRow, startRow + nRow - 1L + colNames),
-    new_cols                = c(startCol, startCol + nCol - 1L),
-    check_table_header_only = TRUE,
-    error_msg               = "Cannot overwrite table headers. Avoid writing over the header row or see getTables() & removeTables() to remove the table object."
-  )
 
   ## write autoFilter, can only have a single filter per worksheet
   if (withFilter) {

--- a/R/writeData.R
+++ b/R/writeData.R
@@ -45,7 +45,7 @@
 #' @param na.string If not NULL, and if `keepNA` is `TRUE`, NA values are converted to this string in Excel.
 #' @param name If not NULL, a named region is defined.
 #' @param sep Only applies to list columns. The separator used to collapse list columns to a character vector e.g. sapply(x$list_column, paste, collapse = sep).
-#' @param overwrite If `TRUE`, remove existing cell values in the target worksheet before writing `x`.
+#' @param overwrite If `TRUE`, remove all existing cell values from the entire target worksheet before writing `x` (not just the cells in the target write range).
 #' @seealso [writeDataTable()]
 #' @export writeData
 #' @details Formulae written using writeFormula to a Workbook object will not get picked up by read.xlsx().

--- a/man/writeData.Rd
+++ b/man/writeData.Rd
@@ -88,7 +88,7 @@ each column. If "\code{all}" all cell borders are drawn.}
 
 \item{sep}{Only applies to list columns. The separator used to collapse list columns to a character vector e.g. sapply(x$list_column, paste, collapse = sep).}
 
-\item{overwrite}{If \code{TRUE}, remove existing cell values in the target worksheet before writing \code{x}.}
+\item{overwrite}{If \code{TRUE}, clear all existing cell contents on the target worksheet before writing \code{x}.}
 
 \item{row.names, col.names}{Deprecated, please use \code{rowNames}, \code{colNames} instead}
 }

--- a/man/writeData.Rd
+++ b/man/writeData.Rd
@@ -88,9 +88,9 @@ each column. If "\code{all}" all cell borders are drawn.}
 
 \item{sep}{Only applies to list columns. The separator used to collapse list columns to a character vector e.g. sapply(x$list_column, paste, collapse = sep).}
 
-\item{overwrite}{If \code{TRUE}, clear all existing cell contents on the target worksheet before writing \code{x}.}
-
 \item{row.names, col.names}{Deprecated, please use \code{rowNames}, \code{colNames} instead}
+
+\item{overwrite}{If \code{TRUE}, remove all existing cell values from the entire target worksheet before writing \code{x} (not just the cells in the target write range).}
 }
 \value{
 invisible(0)

--- a/man/writeData.Rd
+++ b/man/writeData.Rd
@@ -24,7 +24,8 @@ writeData(
   name = NULL,
   sep = ", ",
   col.names,
-  row.names
+  row.names,
+  overwrite = FALSE
 )
 }
 \arguments{
@@ -86,6 +87,8 @@ each column. If "\code{all}" all cell borders are drawn.}
 \item{name}{If not NULL, a named region is defined.}
 
 \item{sep}{Only applies to list columns. The separator used to collapse list columns to a character vector e.g. sapply(x$list_column, paste, collapse = sep).}
+
+\item{overwrite}{If \code{TRUE}, remove existing cell values in the target worksheet before writing \code{x}.}
 
 \item{row.names, col.names}{Deprecated, please use \code{rowNames}, \code{colNames} instead}
 }

--- a/tests/testthat/test-writeData.R
+++ b/tests/testthat/test-writeData.R
@@ -67,3 +67,35 @@ test_that("as.character.formula() works [312]", {
   expect_identical(before, middle, ignore.environment = TRUE)
   expect_identical(before, end,    ignore.environment = TRUE)
 })
+
+
+test_that("writeData(overwrite = TRUE) works (#536)", {
+  wb <- createWorkbook()
+  addWorksheet(wb, "sheet")
+
+  old <- data.frame(a = 1:6, b = letters[1:6], stringsAsFactors = FALSE)
+  new <- old[1:4, , drop = FALSE]
+
+  writeData(wb, "sheet", old)
+  writeData(wb, "sheet", new)
+  out_no_overwrite <- readWorkbook(wb, "sheet")
+  expect_equal(nrow(out_no_overwrite), 6)
+
+  writeData(wb, "sheet", new, overwrite = TRUE)
+  out_overwrite <- readWorkbook(wb, "sheet")
+  expect_equal(out_overwrite, new)
+
+  wb2 <- createWorkbook()
+  addWorksheet(wb2, "sheet")
+  tab_df <- data.frame(x = 1:2)
+  writeDataTable(wb2, "sheet", tab_df)
+  before <- readWorkbook(wb2, "sheet")
+
+  expect_error(
+    writeData(wb2, "sheet", data.frame(y = 1), overwrite = TRUE),
+    "Cannot overwrite table headers"
+  )
+
+  after <- readWorkbook(wb2, "sheet")
+  expect_equal(after, before)
+})


### PR DESCRIPTION
I introduced `overwrite = TRUE` in `writeData()` to fix a common rewrite issue.

In a typical workflow, users read an existing worksheet, filter rows, and write the filtered result back to the same sheet.
When the filtered result has fewer rows than the original data, the previous behavior could leave stale trailing rows in the worksheet.

Before this change:

1. `writeData()` only overwrote the current target write range.
2. Cells outside that new range were not cleared automatically.
3. Users often had to manually call `deleteData()` and calculate row/column ranges,
4. Replacing data by `removeWorksheet()` + `addWorksheet()` could also change the original sheet order.

This was error-prone and easy to misuse.

After this change:

1. `writeData(..., overwrite = TRUE)` clears existing worksheet cell data before writing.
2. Rewrite workflows now produce clean outputs without stale rows.
3. Default behavior remains unchanged (`overwrite = FALSE`), so existing code stays backward compatible.

In short, this change improves correctness for filtered rewrite scenarios while keeping the original API behavior intact for all existing callers.

#### Reproducible Setup: Generate Test Excel File
```R
library(tidyverse)
library(openxlsx)
packageVersion(pkg = "openxlsx")
#4.2.8.1

result <- iris |>
  group_by(Species) |>
  slice_head(n = 2)

dim(result)
result
# A tibble: 6 × 5
# Groups:   Species [3]
#   Sepal.Length Sepal.Width Petal.Length Petal.Width Species   
#          <dbl>       <dbl>        <dbl>       <dbl> <fct>     
# 1          5.1         3.5          1.4         0.2 setosa    
# 2          4.9         3            1.4         0.2 setosa    
# 3          7           3.2          4.7         1.4 versicolor
# 4          6.4         3.2          4.5         1.5 versicolor
# 5          6.3         3.3          6           2.5 virginica 
# 6          5.8         2.7          5.1         1.9 virginica 

filename <- "test.xlsx"
write.xlsx(x = list(iris=result),  filename)

wb <- loadWorkbook(filename)
name <- getSheetNames(filename)

tbl <-readWorkbook(wb, name)
tbl
# Sepal.Length Sepal.Width Petal.Length Petal.Width    Species
# 1          5.1         3.5          1.4         0.2     setosa
# 2          4.9         3.0          1.4         0.2     setosa
# 3          7.0         3.2          4.7         1.4 versicolor
# 4          6.4         3.2          4.5         1.5 versicolor
# 5          6.3         3.3          6.0         2.5  virginica
# 6          5.8         2.7          5.1         1.9  virginica

df <- tbl |> 
  dplyr::mutate(isFiltered = dplyr::if_else(Sepal.Width > 3.5 | Sepal.Width <= 3.0, "drop", "keep" )) |>
  dplyr::filter(isFiltered == "keep") |>
  dplyr::relocate(isFiltered)

df
# isSelected Sepal.Length Sepal.Width Petal.Length Petal.Width    Species
# 1                     5.1         3.5          1.4         0.2     setosa
# 2                     7.0         3.2          4.7         1.4 versicolor
# 3                     6.4         3.2          4.5         1.5 versicolor
# 4                     6.3         3.3          6.0         2.5  virginica

# writeData
writeData(wb, sheet = name, df)
outxlsx <- "testoutput.xlsx"
saveWorkbook(wb, outxlsx, overwrite = TRUE)


tmp <-readWorkbook(outxlsx, name)
tmp
# isFiltered Sepal.Length Sepal.Width Petal.Length Petal.Width    Species
# 1       keep          5.1         3.5          1.4         0.2     setosa
# 2       keep          7.0         3.2          4.7         1.4 versicolor
# 3       keep          6.4         3.2          4.5         1.5 versicolor
# 4       keep          6.3         3.3          6.0         2.5  virginica
# 5        6.3          3.3         6.0          2.5   virginica       <NA>
# 6        5.8          2.7         5.1          1.9   virginica       <NA>

```

Explanation (without overwrite):

1. Input: original worksheet has 6 rows, filtered `df` has 4 rows.
2. Action: `writeData(wb, sheet = name, df)` writes only the new target range.
3. Output: rows 5-6 remain from previous data, so stale trailing rows are visible.
4. Drawback: users must manually clear old ranges (for example with `deleteData()`) before writing.

```R
wb <- loadWorkbook(filename)
name <- getSheetNames(filename)

tbl <-readWorkbook(wb, name)
tbl
# Sepal.Length Sepal.Width Petal.Length Petal.Width    Species
# 1          5.1         3.5          1.4         0.2     setosa
# 2          4.9         3.0          1.4         0.2     setosa
# 3          7.0         3.2          4.7         1.4 versicolor
# 4          6.4         3.2          4.5         1.5 versicolor
# 5          6.3         3.3          6.0         2.5  virginica
# 6          5.8         2.7          5.1         1.9  virginica

df <- tbl |> 
  dplyr::mutate(isFiltered = dplyr::if_else(Sepal.Width > 3.5 | Sepal.Width <= 3.0, "drop", "keep" )) |>
  dplyr::filter(isFiltered == "keep") |>
  dplyr::relocate(isFiltered)

df
# isSelected Sepal.Length Sepal.Width Petal.Length Petal.Width    Species
# 1                     5.1         3.5          1.4         0.2     setosa
# 2                     7.0         3.2          4.7         1.4 versicolor
# 3                     6.4         3.2          4.5         1.5 versicolor
# 4                     6.3         3.3          6.0         2.5  virginica

# writeData
writeData(wb, sheet = name, df, overwrite=TRUE)
outxlsx <- "testoutput1.xlsx"
saveWorkbook(wb, outxlsx, overwrite = TRUE)


tmp <-readWorkbook(outxlsx, name)
tmp
# isFiltered Sepal.Length Sepal.Width Petal.Length Petal.Width    Species
# 1       keep          5.1         3.5          1.4         0.2     setosa
# 2       keep          7.0         3.2          4.7         1.4 versicolor
# 3       keep          6.4         3.2          4.5         1.5 versicolor
# 4       keep          6.3         3.3          6.0         2.5  virginica
```

Explanation (with overwrite):

1. Input: same as above (6 original rows, 4 filtered rows).
2. Action: `writeData(wb, sheet = name, df, overwrite=TRUE)` clears existing worksheet cell data before writing.
3. Output: only the 4 filtered rows remain; no stale trailing rows.
4. Benefit: no manual `deleteData()` range calculation, and no need to remove/recreate the worksheet.