### PR TITLE
Fix date format code length checks

### DIFF
--- a/R/readWorkbook.R
+++ b/R/readWorkbook.R
@@ -483,7 +483,7 @@ read.xlsx.default <- function(
       
       ## this regex defines what "looks" like a date
       dateIds <- numFmtsIds[!grepl("[^mdyhsapAMP[:punct:] ]", formatCodes) &
-          nchar(formatCodes > 3)]
+          nchar(formatCodes) > 3]
     }
     
     dateIds <- c(dateIds, 14)

--- a/R/workbook_read_workbook.R
+++ b/R/workbook_read_workbook.R
@@ -314,7 +314,7 @@ read.xlsx.Workbook <- function(xlsxFile,
 
       ## this regex defines what "looks" like a date
       format_codes <- gsub(".*(?<=\\])|@", "", format_codes, perl = TRUE)
-      sO <- sO[(!grepl("[^mdyhsapAMP[:punct:] ]", format_codes) & nchar(format_codes > 3)) | format_codes == 14]
+      sO <- sO[(!grepl("[^mdyhsapAMP[:punct:] ]", format_codes) & nchar(format_codes) > 3) | format_codes == 14]
     }
 
     if (length(sO) > 0) {

--- a/tests/testthat/test-date_detection_format_codes.R
+++ b/tests/testthat/test-date_detection_format_codes.R
@@ -1,0 +1,21 @@
+context("Date detection: format-code length check")
+
+test_that("short date-like format codes are not detected as dates", {
+  tmp <- tempfile(fileext = ".xlsx")
+  on.exit(unlink(tmp), add = TRUE)
+
+  wb <- createWorkbook()
+  addWorksheet(wb, "Sheet1")
+  writeData(wb, "Sheet1", 44927L, colNames = FALSE)
+  addStyle(wb, "Sheet1", createStyle(numFmt = "m"), rows = 1, cols = 1, stack = FALSE)
+  saveWorkbook(wb, tmp, overwrite = TRUE)
+
+  expect_false(inherits(
+    read.xlsx(tmp, sheet = 1, colNames = FALSE, detectDates = TRUE)[[1]],
+    "Date"
+  ))
+  expect_false(inherits(
+    read.xlsx(wb, sheet = 1, colNames = FALSE, detectDates = TRUE)[[1]],
+    "Date"
+  ))
+})


### PR DESCRIPTION
Date-format detection used nchar(formatCodes > 3) instead of nchar(formatCodes) > 3. Consequently, the intended minimum-length check was ineffective and short date-like formats such as "m" could cause numeric cells to be incorrectly converted to dates.

Found with https://github.com/sims1253/ry